### PR TITLE
LA-326 Testext environment support; expanded Redshift code and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,12 @@ tox -e test -- tests/test_externals/
 
 # Lint specific file(s)
 tox -e lint-py -- scripts/cohort_fixtures.py
+
+# Run testext tests
+
+Tests marked `@pytest.mark.testext` require actual connections to external services, and are not run as part of a normal tox execution. They can be run by directly invoking PyTest with the 'testext' environment specified.
+
+NESSIE_ENV=testext pytest
+
+Configuration for testext runs can be placed in a testext-local.py file under your NESSIE_LOCAL_CONFIGS directory. See config/testext.py for a model.
 ```

--- a/config/default.py
+++ b/config/default.py
@@ -58,9 +58,6 @@ LOCH_CANVAS_DATA_REQUESTS_TERM_REGEXP = 'regexp for requests file url parsing'
 LOCH_S3_BUCKET = 'bucket name'
 LOCH_S3_REGION = 'aws region'
 
-LOCH_SCHEMA_BOAC = 'BOAC schema name'
-LOCH_SCHEMA_CANVAS = 'Canvas schema name'
-
 LOGGING_FORMAT = '[%(asctime)s] - %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
 LOGGING_LOCATION = 'nessie.log'
 LOGGING_LEVEL = logging.DEBUG
@@ -70,6 +67,9 @@ REDSHIFT_HOST = 'redshift cluster'
 REDSHIFT_PASSWORD = 'password'
 REDSHIFT_PORT = 1234
 REDSHIFT_USER = 'username'
+
+REDSHIFT_SCHEMA_BOAC = 'BOAC schema name'
+REDSHIFT_SCHEMA_CANVAS = 'Canvas schema name'
 
 WORKER_HOST = 'app url'
 WORKER_USERNAME = 'username'

--- a/config/testext.py
+++ b/config/testext.py
@@ -1,0 +1,13 @@
+# Redshift connection parameters.
+
+REDSHIFT_DATABASE = 'database'
+REDSHIFT_HOST = 'redshift cluster'
+REDSHIFT_PASSWORD = 'password'
+REDSHIFT_PORT = 1234
+REDSHIFT_USER = 'username'
+
+# Schema names. Since Redshift instances are shared between environments, choose something that can
+# be repeatedly created and torn down without conflicts.
+
+REDSHIFT_SCHEMA_BOAC = 'testext_paulkerschen_boac'
+REDSHIFT_SCHEMA_CANVAS = 'testext_paulkerschen_canvas'

--- a/consoler.py
+++ b/consoler.py
@@ -39,7 +39,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 * Click the bug icon to start a debugging session:
 
 >>> from nessie.externals import redshift
->>> assignments = redshift.fetch_tuples('select * from canvas.assignment_dim limit 10')
+>>> assignments = redshift.fetch('select * from canvas.assignment_dim limit 10')
 >>> pp(assignments)
 [
     Record(id=12340000001234567, canvas_id=1234567 course_id=12340000009876564, title='Diagnostic Essay'...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,20 @@ import nessie.factory
 import pytest
 
 
-os.environ['NESSIE_ENV'] = 'test'
+# Test environment defaults to 'test' unless 'testext' is explicitly specified.
+
+if os.environ.get('NESSIE_ENV') != 'testext':
+    os.environ['NESSIE_ENV'] = 'test'
+
+
+# When NESSIE_ENV is 'testext', only tests marked @pytest.mark.testext will run. Otherwise,
+# all other tests will run.
+
+def pytest_cmdline_preparse(args):
+    if os.environ['NESSIE_ENV'] == 'testext':
+        args[:] = ['-m', 'testext'] + args
+    else:
+        args[:] = ['-m', 'not testext'] + args
 
 
 # Because app and db fixtures are only created once per pytest run, individual tests

--- a/tests/test_externals/test_redshift.py
+++ b/tests/test_externals/test_redshift.py
@@ -25,7 +25,24 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 
 from nessie.externals import redshift
+import psycopg2.sql
+import pytest
 from tests.util import capture_app_logs
+
+
+@pytest.fixture()
+def schema(app):
+    schema = psycopg2.sql.Identifier(app.config['REDSHIFT_SCHEMA_BOAC'])
+    redshift.execute('CREATE SCHEMA IF NOT EXISTS {schema}', schema=schema)
+    yield
+    redshift.execute('DROP SCHEMA IF EXISTS {schema} CASCADE', schema=schema)
+
+
+@pytest.fixture()
+def ensure_drop_schema(app):
+    yield
+    schema = psycopg2.sql.Identifier(app.config['REDSHIFT_SCHEMA_BOAC'])
+    redshift.execute('DROP SCHEMA IF EXISTS {schema} CASCADE', schema=schema)
 
 
 class TestRedshift:
@@ -37,3 +54,69 @@ class TestRedshift:
             app.config['REDSHIFT_HOST'] = 'H.C. Earwicker'
             redshift.execute('SELECT 1')
             assert 'could not translate host name "H.C. Earwicker" to address' in caplog.text
+
+    @pytest.mark.testext
+    def test_schema_creation_drop(self, app, caplog, ensure_drop_schema):
+        """Can create and drop schemata on a real Redshift instance."""
+        schema_name = app.config['REDSHIFT_SCHEMA_BOAC']
+        schema = psycopg2.sql.Identifier(schema_name)
+        with capture_app_logs(app):
+            result = redshift.execute('CREATE SCHEMA {schema}', schema=schema)
+            assert result == 'CREATE SCHEMA'
+
+            result = redshift.execute('CREATE SCHEMA {schema}', schema=schema)
+            assert result is None
+            assert f'Schema "{schema_name}" already exists' in caplog.text
+
+            result = redshift.execute('DROP SCHEMA {schema}', schema=schema)
+            assert result == 'DROP SCHEMA'
+
+    @pytest.mark.testext
+    def test_complex_query(self, app, schema):
+        """Can execute complex queries against Redshift."""
+        schema = psycopg2.sql.Identifier(app.config['REDSHIFT_SCHEMA_BOAC'])
+        query = """CREATE TABLE {schema}.students (
+                  sid character varying(80) NOT NULL,
+                  uid character varying(80),
+                  first_name character varying(255) NOT NULL,
+                  last_name character varying(255) NOT NULL,
+                  in_intensive_cohort boolean DEFAULT false NOT NULL,
+                  is_active_asc boolean DEFAULT true NOT NULL,
+                  status_asc character varying(80),
+                  created_at timestamp with time zone NOT NULL,
+                  updated_at timestamp with time zone NOT NULL
+                );
+                INSERT INTO {schema}.students
+                  VALUES ('11667051', '61889', 'Brigitte', 'Lin', true, true, NULL,
+                          '2018-03-07 15:19:17.18972-08', '2018-03-07 15:19:17.189727-08');
+                INSERT INTO {schema}.students
+                  VALUES ('8901234567', '1022796', 'John', 'Crossman', true, true, NULL,
+                          '2018-03-07 15:19:17.200198-08', '2018-03-07 15:19:17.200205-08');
+                INSERT INTO {schema}.students
+                  VALUES ('2345678901', '2040', 'Oliver', 'Heyer', false, true, NULL,
+                          '2018-03-07 15:19:17.204676-08', '2018-03-07 15:19:17.204682-08');
+                INSERT INTO {schema}.students
+                  VALUES ('3456789012', '242881', 'Paul', 'Kerschen', true, true, NULL,
+                          '2018-03-07 15:19:17.214502-08', '2018-03-07 15:19:17.214507-08');
+                INSERT INTO {schema}.students
+                  VALUES ('5678901234', '1133399', 'Sandeep', 'Jayaprakash', false, true, NULL,
+                          '2018-03-07 15:19:17.220223-08', '2018-03-07 15:19:17.220229-08');
+                INSERT INTO {schema}.students
+                  VALUES ('7890123456', '1049291', 'Paul', 'Farestveit', true, true, NULL,
+                          '2018-03-07 15:19:17.228017-08', '2018-03-07 15:19:17.228024-08');
+                INSERT INTO {schema}.students
+                  VALUES ('838927492', '211159', 'Siegfried', 'Schlemiel', true, false, 'Trouble',
+                          '2018-03-07 15:19:17.234875-08', '2018-03-07 15:19:17.240878-08');
+                ALTER TABLE {schema}.students ADD CONSTRAINT students_pkey PRIMARY KEY (sid);
+            """
+        result = redshift.execute(query, schema=schema)
+        assert result == 'ALTER TABLE'
+
+        result = redshift.fetch('SELECT COUNT(*) FROM {schema}.students', schema=schema)
+        assert len(result) == 1
+        assert result[0].count == 7
+
+        result = redshift.fetch("SELECT last_name FROM {schema}.students WHERE first_name = 'Paul' ORDER BY last_name", schema=schema)
+        assert len(result) == 2
+        assert result[0].last_name == 'Farestveit'
+        assert result[1].last_name == 'Kerschen'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-326

Since these external tests require access to private configs (and may be slow), they don't run under Travis. They could conceivably be incorporated into a CodePipeline run, as CalCentral/Junction does on Bamboo.