### PR TITLE
LA-338 Follow-up: no-op mock must take no-op kwargs

### DIFF
--- a/nessie/lib/mockingbird.py
+++ b/nessie/lib/mockingbird.py
@@ -306,7 +306,7 @@ def _get_fixtures_path():
 
 
 @contextmanager
-def _noop_mock(url):
+def _noop_mock(url, **kwargs):
     yield None
 
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-338

Follow-up to #6; BOAC version is ets-berkeley-edu/boac#511.