### PR TITLE
LA-381, buildspec and build-summary file for /api/version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Local configs
 config/*-local.py
+config/build-summary.json
 
 # MacNoise
 .DS_Store
@@ -56,6 +57,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache/
 nosetests.xml
 coverage.xml
 *.cover

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,35 @@
+version: 0.2
+
+eb_codebuild_settings:
+  CodeBuildServiceRole: arn:aws:iam::697877139013:role/service-role/code-build-nessie-service-role
+  ComputeType: BUILD_GENERAL1_MEDIUM
+  Image: aws/codebuild/nodejs:6.3.1
+  Timeout: 60
+
+phases:
+  install:
+    commands:
+      - echo "install phase"
+
+  pre_build:
+    commands:
+      - echo "pre_build phase"
+
+  build:
+    commands:
+      - echo "build phase"
+
+  post_build:
+    commands:
+      - chmod 755 ./scripts/*.sh
+      - ./scripts/create-build-summary.sh
+
+artifacts:
+  files:
+  - '.ebextensions/**/*'
+  - 'config/**/*'
+  - 'consoler.py'
+  - 'fixtures/**/*'
+  - 'nessie/**/*'
+  - 'requirements.txt'
+  - 'run.py'

--- a/scripts/create-build-summary.sh
+++ b/scripts/create-build-summary.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Abort immediately if a command fails
+set -e
+
+shortGitHash=$(echo "${CODEBUILD_RESOLVED_SOURCE_VERSION}" | cut -c1-7)
+
+cat << EOF > "${PWD}/config/build-summary.json"
+{
+  "build": {
+    "artifact": "${CODEBUILD_SOURCE_VERSION}",
+    "gitCommit": "${shortGitHash}"
+  }
+}
+EOF
+
+exit 0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-381
https://jira.ets.berkeley.edu/jira/browse/LA-392

* `code-build-nessie-service-role` will be created in CodeBuild setup (coming soon)
* Regarding build-summary, `gitCommit` in /api/version is useful. 