### PR TITLE
LA-380, Nessie gets aws:elbv2:listener:443:SSLCertificateArns

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -43,7 +43,7 @@ option_settings:
   aws:elbv2:listener:443:
     ListenerEnabled: 'true'
     Protocol: HTTPS
-    SSLCertificateArns:
+    SSLCertificateArns: arn:aws:acm:us-west-2:697877139013:certificate/65fe6607-e705-4d82-8b1d-09b0a968cb50
 
   # Load Balancer security group
   aws:elbv2:loadbalancer:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-380

Thanks to Darlene, I did nothing more than grab the `arn` from AWS Certificate Manager.
