### PR TITLE
LA-397 Make SIS enrollment status available to loch queries

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -54,9 +54,11 @@ CANVAS_DATA_HOST = 'foo.instructure.com'
 LOCH_S3_BUCKET = 'bucket_name'
 LOCH_S3_REGION = 'us-west-2'
 
-LOCH_S3_CANVAS_DATA_PATH_CURRENT_TERM = 's3/path/to/current/term'
-LOCH_S3_CANVAS_DATA_PATH_DAILY = 's3/path/to/daily'
-LOCH_S3_CANVAS_DATA_PATH_HISTORICAL = 's3/path/to/historical'
+LOCH_S3_CANVAS_DATA_PATH_CURRENT_TERM = 'canvas/path/to/current/term'
+LOCH_S3_CANVAS_DATA_PATH_DAILY = 'canvas/path/to/daily'
+LOCH_S3_CANVAS_DATA_PATH_HISTORICAL = 'canvas/path/to/historical'
+
+LOCH_S3_SIS_DATA_PATH_DAILY = 'sis/path/to/daily'
 
 LOCH_CANVAS_DATA_REQUESTS_CUTOFF_DATE = '20180101'
 
@@ -74,6 +76,7 @@ REDSHIFT_IAM_ROLE = 'iam role'
 
 REDSHIFT_SCHEMA_BOAC = 'BOAC schema name'
 REDSHIFT_SCHEMA_CANVAS = 'Canvas schema name'
+REDSHIFT_SCHEMA_SIS = 'SIS schema name'
 
 WORKER_HOST = 'hard-working-nessie.berkeley.edu'
 WORKER_USERNAME = 'username'

--- a/config/default.py
+++ b/config/default.py
@@ -76,6 +76,7 @@ REDSHIFT_IAM_ROLE = 'iam role'
 
 REDSHIFT_SCHEMA_BOAC = 'BOAC schema name'
 REDSHIFT_SCHEMA_CANVAS = 'Canvas schema name'
+REDSHIFT_SCHEMA_INTERMEDIATE = 'Intermediate schema name'
 REDSHIFT_SCHEMA_SIS = 'SIS schema name'
 
 WORKER_HOST = 'hard-working-nessie.berkeley.edu'

--- a/config/testext.py
+++ b/config/testext.py
@@ -11,3 +11,4 @@ REDSHIFT_USER = 'username'
 
 REDSHIFT_SCHEMA_BOAC = 'testext_paulkerschen_boac'
 REDSHIFT_SCHEMA_CANVAS = 'testext_paulkerschen_canvas'
+REDSHIFT_SCHEMA_SIS = 'testext_paulkerschen_sis'

--- a/config/testext.py
+++ b/config/testext.py
@@ -11,4 +11,5 @@ REDSHIFT_USER = 'username'
 
 REDSHIFT_SCHEMA_BOAC = 'testext_paulkerschen_boac'
 REDSHIFT_SCHEMA_CANVAS = 'testext_paulkerschen_canvas'
+REDSHIFT_SCHEMA_INTERMEDIATE = 'testext_paulkerschen_intermediate'
 REDSHIFT_SCHEMA_SIS = 'testext_paulkerschen_sis'

--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -31,6 +31,7 @@ from nessie.api.errors import BadRequestError
 from nessie.jobs.create_canvas_schema import CreateCanvasSchema
 from nessie.jobs.create_sis_schema import CreateSisSchema
 from nessie.jobs.generate_boac_analytics import GenerateBoacAnalytics
+from nessie.jobs.generate_intermediate_tables import GenerateIntermediateTables
 from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 from nessie.jobs.sync_file_to_s3 import SyncFileToS3
 from nessie.lib.http import tolerant_jsonify
@@ -54,6 +55,13 @@ def create_sis_schema():
 @auth_required
 def generate_boac_analytics():
     job_started = GenerateBoacAnalytics().run_async()
+    return respond_with_status(job_started)
+
+
+@app.route('/api/job/generate_intermediate_tables', methods=['POST'])
+@auth_required
+def generate_intermediate_tables():
+    job_started = GenerateIntermediateTables().run_async()
     return respond_with_status(job_started)
 
 

--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -29,6 +29,7 @@ from flask import current_app as app, request
 from nessie.api.auth_helper import auth_required
 from nessie.api.errors import BadRequestError
 from nessie.jobs.create_canvas_schema import CreateCanvasSchema
+from nessie.jobs.create_sis_schema import CreateSisSchema
 from nessie.jobs.generate_boac_analytics import GenerateBoacAnalytics
 from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 from nessie.jobs.sync_file_to_s3 import SyncFileToS3
@@ -39,6 +40,13 @@ from nessie.lib.http import tolerant_jsonify
 @auth_required
 def create_canvas_schema():
     job_started = CreateCanvasSchema().run_async()
+    return respond_with_status(job_started)
+
+
+@app.route('/api/job/create_sis_schema', methods=['POST'])
+@auth_required
+def create_sis_schema():
+    job_started = CreateSisSchema().run_async()
     return respond_with_status(job_started)
 
 

--- a/nessie/externals/redshift.py
+++ b/nessie/externals/redshift.py
@@ -70,7 +70,8 @@ def _execute(sql, operation, **kwargs):
     """
     result = None
     try:
-        sql = psycopg2.sql.SQL(sql).format(**kwargs)
+        if kwargs:
+            sql = psycopg2.sql.SQL(sql).format(**kwargs)
         with get_cursor(operation) as cursor:
             cursor.execute(sql)
             if operation == 'read':

--- a/nessie/jobs/background_job.py
+++ b/nessie/jobs/background_job.py
@@ -44,16 +44,24 @@ def get_s3_canvas_daily_path():
     return app.config['LOCH_S3_CANVAS_DATA_PATH_DAILY'] + '/' + today_hash + '-' + today
 
 
+def get_s3_sis_daily_path():
+    today = localize_datetime(datetime.now()).strftime('%Y-%m-%d')
+    today_hash = hashlib.md5(today.encode('utf-8')).hexdigest()
+    return app.config['LOCH_S3_SIS_DATA_PATH_DAILY'] + '/' + today_hash + '-' + today
+
+
 def resolve_sql_template(sql_filename):
     """Our DDL template files are simple enough to use standard Python string formatting."""
     s3_prefix = 's3://' + app.config['LOCH_S3_BUCKET'] + '/'
     template_data = {
         'redshift_schema_boac': app.config['REDSHIFT_SCHEMA_BOAC'],
         'redshift_schema_canvas': app.config['REDSHIFT_SCHEMA_CANVAS'],
+        'redshift_schema_sis': app.config['REDSHIFT_SCHEMA_SIS'],
         'redshift_iam_role': app.config['REDSHIFT_IAM_ROLE'],
         'loch_s3_canvas_data_path_today': s3_prefix + get_s3_canvas_daily_path(),
         'loch_s3_canvas_data_path_historical': s3_prefix + app.config['LOCH_S3_CANVAS_DATA_PATH_HISTORICAL'],
         'loch_s3_canvas_data_path_current_term': s3_prefix + app.config['LOCH_S3_CANVAS_DATA_PATH_CURRENT_TERM'],
+        'loch_s3_sis_data_path_today': s3_prefix + get_s3_sis_daily_path(),
     }
     with open(app.config['BASE_DIR'] + f'/nessie/sql_templates/{sql_filename}') as file:
         template_string = file.read()

--- a/nessie/jobs/background_job.py
+++ b/nessie/jobs/background_job.py
@@ -56,6 +56,7 @@ def resolve_sql_template(sql_filename):
     template_data = {
         'redshift_schema_boac': app.config['REDSHIFT_SCHEMA_BOAC'],
         'redshift_schema_canvas': app.config['REDSHIFT_SCHEMA_CANVAS'],
+        'redshift_schema_intermediate': app.config['REDSHIFT_SCHEMA_INTERMEDIATE'],
         'redshift_schema_sis': app.config['REDSHIFT_SCHEMA_SIS'],
         'redshift_iam_role': app.config['REDSHIFT_IAM_ROLE'],
         'loch_s3_canvas_data_path_today': s3_prefix + get_s3_canvas_daily_path(),

--- a/nessie/jobs/create_sis_schema.py
+++ b/nessie/jobs/create_sis_schema.py
@@ -1,0 +1,41 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+"""Logic for SIS schema creation job."""
+
+
+from flask import current_app as app
+from nessie.externals import redshift
+from nessie.jobs.background_job import BackgroundJob, resolve_sql_template
+
+
+class CreateSisSchema(BackgroundJob):
+
+    def run(self):
+        app.logger.info(f'Starting SIS schema creation job...')
+        resolved_ddl = resolve_sql_template('create_sis_schema.template.sql')
+        redshift.execute_ddl_script(resolved_ddl)
+        app.logger.info(f'SIS schema creation job completed')

--- a/nessie/jobs/generate_intermediate_tables.py
+++ b/nessie/jobs/generate_intermediate_tables.py
@@ -1,0 +1,41 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+"""Logic for intermediate table generation job."""
+
+
+from flask import current_app as app
+from nessie.externals import redshift
+from nessie.jobs.background_job import BackgroundJob, resolve_sql_template
+
+
+class GenerateIntermediateTables(BackgroundJob):
+
+    def run(self):
+        app.logger.info(f'Starting intermediate table generation job...')
+        resolved_ddl = resolve_sql_template('create_intermediate_schema.template.sql')
+        redshift.execute_ddl_script(resolved_ddl)
+        app.logger.info(f'Intermediate table generation job completed')

--- a/nessie/sql_templates/create_intermediate_schema.template.sql
+++ b/nessie/sql_templates/create_intermediate_schema.template.sql
@@ -1,0 +1,156 @@
+/**
+ * Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+CREATE SCHEMA IF NOT EXISTS {redshift_schema_intermediate};
+
+DROP TABLE IF EXISTS {redshift_schema_intermediate}.course_sections;
+
+/*
+ * Use SIS integration IDs for Canvas sections to generate a master mapping between Canvas and SIS sections. A
+ * FULL OUTER JOIN is used to include all sections from Canvas and SIS data, whether integrated or not.
+ */
+
+CREATE TABLE {redshift_schema_intermediate}.course_sections
+INTERLEAVED SORTKEY (canvas_course_id, canvas_section_id, sis_term_id, sis_section_id)
+AS (
+    /*
+     * Translate SIS section IDs from Canvas data, when parseable, to section and term ids as represented in SIS
+     * data. Otherwise leave blank.
+     */
+    WITH extracted_section_ids AS (
+        SELECT
+            s.canvas_id AS canvas_section_id,
+            CASE
+                /*
+                 * Note doubled curly braces in the regexp, escaped for Python string formatting.
+                 */
+                WHEN s.sis_source_id ~ '^SEC:20[0-9]{{2}}-[BCD]-[0-9]{{5}}' THEN
+                    ('2' + substring(s.sis_source_id, 7, 2) + translate(substring(s.sis_source_id, 10, 1), 'BCD', '258'))::int
+                ELSE NULL END
+                AS sis_term_id,
+            CASE
+                WHEN s.sis_source_id ~ '^SEC:20[0-9]{{2}}-[BCD]-[0-9]{{5}}' THEN
+                    SUBSTRING(s.sis_source_id, 12, 5)::int
+                ELSE NULL END
+                AS sis_section_id
+        FROM {redshift_schema_canvas}.course_section_dim s
+    )
+    SELECT
+        c.canvas_id AS canvas_course_id,
+        s.canvas_id AS canvas_section_id,
+        c.name AS canvas_course_name,
+        s.name AS canvas_section_name,
+        extracted_section_ids.sis_term_id,
+        extracted_section_ids.sis_section_id,
+        sc.course_display_name AS sis_course_name,
+        sc.instruction_format AS sis_instruction_format,
+        sc.section_num AS sis_section_num,
+        sc.is_primary AS sis_primary
+    FROM {redshift_schema_canvas}.course_section_dim s
+    LEFT JOIN {redshift_schema_canvas}.course_dim c
+        ON s.course_id = c.id
+    LEFT JOIN extracted_section_ids ON s.canvas_id = extracted_section_ids.canvas_section_id
+    FULL OUTER JOIN {redshift_schema_sis}.courses sc
+        ON extracted_section_ids.sis_term_id = sc.term_id
+        AND extracted_section_ids.sis_section_id = sc.section_id
+    /* Clear out duplicates, since SIS data will contain multiple rows for multiple meetings or instructor assignments. */
+    GROUP BY
+        c.canvas_id, s.canvas_id, c.name, s.name,
+        extracted_section_ids.sis_term_id, extracted_section_ids.sis_section_id,
+        sc.course_display_name, sc.instruction_format, sc.section_num, sc.is_primary
+);
+
+/*
+ * Combine Canvas Data user_dim and pseudonym_dim tabeles to map Canvas and SIS user ids to global Canvas Data ids.
+ * Since multiple mappings frequently exist for a given Canvas id, track only the user_ids which have an active
+ * workflow_state. A handful (about 100) canvas_user_ids have multiple active sis_login_ids, represented in this
+ * table by multiple rows.
+ */
+
+DROP TABLE IF EXISTS {redshift_schema_intermediate}.users;
+
+CREATE TABLE {redshift_schema_intermediate}.users
+INTERLEAVED SORTKEY (canvas_id, uid, sis_user_id)
+AS (
+    SELECT
+        u.id AS global_id,
+        u.canvas_id,
+        u.name,
+        u.sortable_name,
+        p.sis_user_id,
+        p.unique_name AS sis_login_id,
+        /* Extract a numeric-string UID from Canvas sis_login_id if possible, otherwise leave blank. */
+        CASE
+            WHEN REPLACE(p.unique_name, 'inactive-', '') !~ '[A-Za-z]'
+            THEN REPLACE(p.unique_name, 'inactive-', '')
+        ELSE NULL END
+            AS uid
+    FROM
+        {redshift_schema_canvas}.user_dim u
+    LEFT JOIN {redshift_schema_canvas}.pseudonym_dim p ON u.id = p.user_id
+    WHERE
+        p.workflow_state = 'active'
+);
+
+/*
+ * Collect all active student enrollments and note SIS enrollment status, if any, in SIS sections integrated
+ * with the course site.
+ */
+DROP TABLE IF EXISTS {redshift_schema_intermediate}.active_student_enrollments;
+
+CREATE TABLE {redshift_schema_intermediate}.active_student_enrollments
+INTERLEAVED SORTKEY (canvas_user_id, canvas_course_id)
+AS (
+    SELECT
+        {redshift_schema_intermediate}.users.uid AS uid,
+        {redshift_schema_intermediate}.users.canvas_id AS canvas_user_id,
+        {redshift_schema_canvas}.course_dim.canvas_id AS canvas_course_id,
+        /*
+         * MIN ordering happens to match our desired precedence when reconciling enrollment status among multiple
+         * sections: 'E', then 'W', then NULL.
+         */
+        MIN({redshift_schema_sis}.enrollments.enrollment_status) AS sis_enrollment_status
+    FROM
+        {redshift_schema_canvas}.enrollment_fact
+        JOIN {redshift_schema_canvas}.enrollment_dim
+            ON {redshift_schema_canvas}.enrollment_dim.id = {redshift_schema_canvas}.enrollment_fact.enrollment_id
+        JOIN {redshift_schema_intermediate}.users
+            ON {redshift_schema_intermediate}.users.global_id = {redshift_schema_canvas}.enrollment_fact.user_id
+        JOIN {redshift_schema_canvas}.course_dim
+            ON {redshift_schema_canvas}.course_dim.id = {redshift_schema_canvas}.enrollment_fact.course_id
+        LEFT JOIN {redshift_schema_intermediate}.course_sections
+            ON {redshift_schema_canvas}.course_dim.canvas_id = {redshift_schema_intermediate}.course_sections.canvas_course_id
+        LEFT JOIN {redshift_schema_sis}.enrollments ON
+            {redshift_schema_intermediate}.course_sections.sis_section_id = {redshift_schema_sis}.enrollments.section_id AND
+            {redshift_schema_intermediate}.course_sections.sis_term_id = {redshift_schema_sis}.enrollments.term_id AND
+            {redshift_schema_sis}.enrollments.ldap_uid = {redshift_schema_intermediate}.users.uid
+    WHERE
+        {redshift_schema_canvas}.enrollment_dim.type = 'StudentEnrollment'
+        AND {redshift_schema_canvas}.enrollment_dim.workflow_state = 'active'
+    GROUP BY
+        {redshift_schema_intermediate}.users.uid,
+        {redshift_schema_intermediate}.users.canvas_id,
+        {redshift_schema_canvas}.course_dim.canvas_id
+);

--- a/nessie/sql_templates/create_sis_schema.template.sql
+++ b/nessie/sql_templates/create_sis_schema.template.sql
@@ -1,0 +1,86 @@
+/**
+ * Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+--------------------------------------------------------------------
+-- DROP and CREATE EXTERNAL SCHEMA
+--------------------------------------------------------------------
+
+-- Contrary to the documentation, this statement does not actually drop external database tables.
+-- When the external schema is re-created, the table definitions will return as they were.
+DROP SCHEMA IF EXISTS {redshift_schema_sis} CASCADE;
+CREATE EXTERNAL SCHEMA {redshift_schema_sis}
+FROM data catalog
+DATABASE '{redshift_schema_sis}'
+IAM_ROLE '{redshift_iam_role}'
+CREATE EXTERNAL DATABASE IF NOT EXISTS;
+
+--------------------------------------------------------------------
+-- External Tables
+--------------------------------------------------------------------
+
+-- courses
+DROP TABLE IF EXISTS {redshift_schema_sis}.courses CASCADE;
+CREATE EXTERNAL TABLE {redshift_schema_sis}.courses(
+    section_id INT,
+    term_id INT,
+    print_in_schedule_of_classes VARCHAR,
+    is_primary VARCHAR,
+    instruction_format VARCHAR,
+    section_num VARCHAR,
+    course_display_name VARCHAR,
+    enrollment_count INT,
+    instructor_uid VARCHAR,
+    instructor_name VARCHAR,
+    instructor_role_code VARCHAR,
+    meeting_location VARCHAR,
+    meeting_days VARCHAR,
+    meeting_start_time VARCHAR,
+    meeting_end_time VARCHAR,
+    meeting_start_date VARCHAR,
+    meeting_end_date VARCHAR
+)
+ROW FORMAT DELIMITED
+FIELDS TERMINATED BY ','
+STORED AS TEXTFILE
+LOCATION '{loch_s3_sis_data_path_today}/courses';
+
+-- enrollments
+DROP TABLE IF EXISTS {redshift_schema_sis}.enrollments CASCADE;
+CREATE EXTERNAL TABLE {redshift_schema_sis}.enrollments(
+    section_id INT,
+    term_id INT,
+    ldap_uid VARCHAR,
+    sis_id VARCHAR,
+    enrollment_status VARCHAR,
+    waitlist_position INT,
+    units DOUBLE PRECISION,
+    grade VARCHAR,
+    grade_points DOUBLE PRECISION,
+    grading_basis VARCHAR
+)
+ROW FORMAT DELIMITED
+FIELDS TERMINATED BY ','
+STORED AS TEXTFILE
+LOCATION '{loch_s3_sis_data_path_today}/enrollments';

--- a/tests/test_api/test_job_controller.py
+++ b/tests/test_api/test_job_controller.py
@@ -45,6 +45,7 @@ def post_basic_auth(client, path, credentials, data=None):
         '/api/job/create_canvas_schema',
         '/api/job/create_sis_schema',
         '/api/job/generate_boac_analytics',
+        '/api/job/generate_intermediate_tables',
         '/api/job/sync_canvas_snapshots',
         '/api/job/sync_file_to_s3',
     ],
@@ -73,6 +74,7 @@ class TestJobControllerAuthentication:
         '/api/job/create_canvas_schema',
         '/api/job/create_sis_schema',
         '/api/job/generate_boac_analytics',
+        '/api/job/generate_intermediate_tables',
         '/api/job/sync_canvas_snapshots',
     ],
 )

--- a/tests/test_api/test_job_controller.py
+++ b/tests/test_api/test_job_controller.py
@@ -43,6 +43,7 @@ def post_basic_auth(client, path, credentials, data=None):
     'api_path_authenticated',
     [
         '/api/job/create_canvas_schema',
+        '/api/job/create_sis_schema',
         '/api/job/generate_boac_analytics',
         '/api/job/sync_canvas_snapshots',
         '/api/job/sync_file_to_s3',
@@ -70,6 +71,7 @@ class TestJobControllerAuthentication:
     'api_path_no_params',
     [
         '/api/job/create_canvas_schema',
+        '/api/job/create_sis_schema',
         '/api/job/generate_boac_analytics',
         '/api/job/sync_canvas_snapshots',
     ],


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-397

Three commits because the work comes in three parts:

1. Create an external schema in Redshift for our SIS data snapshots;
2. Generate some persistent internal tables to bring together Canvas and SIS data. (I too am suspicious of creating schemata all over the place, but we did seem to need at least one more for generally applicable internal tables that have nothing to do with BOAC as such.)
3. Take some load off BOAC-specific table creation by allowing it to pull data from the intermediate tables, including SIS enrollment status. Queries from the BOAC side can then filter their result sets by enrollment status if desired.