### PR TITLE
LA-401, default listener (port 80) is enabled, but will redirect to 443 per Apache config

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -37,7 +37,7 @@ option_settings:
 
   # Default listener (port 80) is enabled, but will redirect to 443 per Apache config.
   aws:elbv2:listener:default:
-    ListenerEnabled: 'false'
+    ListenerEnabled: 'true'
 
  # Custom load balancer listener (port 433)
   aws:elbv2:listener:443:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-401

As seen in BOAC: https://github.com/ets-berkeley-edu/boac/blob/master/.ebextensions/00_ami.config