### PR TITLE
LA-415 Disable log rotation to S3

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -57,9 +57,6 @@ option_settings:
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
 
-  aws:elasticbeanstalk:hostmanager:
-    LogPublicationControl: 'true'
-
   aws:elasticbeanstalk:cloudwatch:logs:
     StreamLogs: true
     DeleteOnTerminate: false


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-415

The niceness of S3 logs is outweighed by the nastiness of instances restarting every hour.