### PR TITLE
LA-323 Centralized metadata for distributed Canvas sync jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,16 @@ sudo: required
 language: python
 python: "3.6"
 
+addons:
+  postgresql: "9.6"
+
 before_install:
   - cd ${TRAVIS_BUILD_DIR}
+
+  # Set up test db
+  - psql -c 'create database nessie_test;' -U postgres
+  - psql nessie_test -c 'create extension pg_trgm;' -U postgres
+  - psql nessie_test -c 'create role nessie superuser login; alter schema public owner to nessie;' -U postgres
 
 install:
   - pip install google-compute-engine # see https://github.com/tendenci/tendenci/issues/539

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Networked engines supply statistics in education.
 pip3 install -r requirements.txt [--upgrade]
 ```
 
+### Create Postgres user and database for local tests
+
+```
+createuser nessie --no-createdb --no-superuser --no-createrole --pwprompt
+createdb nessie_test --owner=nessie
+```
+
 ### Create local configurations
 
 If you plan to use any resources outside localhost, put your configurations in a separately encrypted area:

--- a/config/default.py
+++ b/config/default.py
@@ -85,6 +85,7 @@ REDSHIFT_IAM_ROLE = 'iam role'
 REDSHIFT_SCHEMA_BOAC = 'BOAC schema name'
 REDSHIFT_SCHEMA_CANVAS = 'Canvas schema name'
 REDSHIFT_SCHEMA_INTERMEDIATE = 'Intermediate schema name'
+REDSHIFT_SCHEMA_METADATA = 'Metadata schema name'
 REDSHIFT_SCHEMA_SIS = 'SIS schema name'
 
 WORKER_HOST = 'hard-working-nessie.berkeley.edu'

--- a/config/test.py
+++ b/config/test.py
@@ -23,42 +23,12 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from contextlib import contextmanager
-import logging
+# The test environment mocks the Redshift interface with a local Postgres db.
 
-import boto3
-import moto
-import responses
+REDSHIFT_DATABASE = 'nessie_test'
+REDSHIFT_HOST = 'localhost'
+REDSHIFT_PASSWORD = 'nessie'
+REDSHIFT_PORT = 5432
+REDSHIFT_USER = 'nessie'
 
-
-@contextmanager
-def capture_app_logs(app):
-    """Temporarily add pytest's LogCaptureHandler to the Flask app logger.
-
-    This makes app logs avilable to the caplog fixture for testing. Due to the way that caplog is set up, this
-    logic regrettably can't go into a fixture itself.
-    """
-    capture_handler = next((h for h in logging.getLogger().handlers if 'LogCaptureHandler' in str(type(h))), None)
-    app.logger.addHandler(capture_handler)
-    yield
-    app.logger.removeHandler(capture_handler)
-
-
-@contextmanager
-def mock_s3(app):
-    # Allow calls to live external URLs during tests; currently our tests are using shakespeare.mit.edu.
-    # TODO See if we can get httpretty and/or responses to sit nicely beside moto in non-testext mode.
-    responses.add_passthru('http://')
-    with moto.mock_s3():
-        s3 = boto3.resource('s3', app.config['LOCH_S3_REGION'])
-        s3.create_bucket(Bucket=app.config['LOCH_S3_BUCKET'])
-        yield s3
-
-
-@contextmanager
-def override_config(app, key, value):
-    """Temporarily override an app config value."""
-    old_value = app.config[key]
-    app.config[key] = value
-    yield
-    app.config[key] = old_value
+REDSHIFT_SCHEMA_METADATA = 'metadata_test'

--- a/config/testext.py
+++ b/config/testext.py
@@ -12,6 +12,7 @@ REDSHIFT_USER = 'username'
 REDSHIFT_SCHEMA_BOAC = 'testext_mynamehere_boac'
 REDSHIFT_SCHEMA_CANVAS = 'testext_mynamehere_canvas'
 REDSHIFT_SCHEMA_INTERMEDIATE = 'testext_mynamehere_intermediate'
+REDSHIFT_SCHEMA_METADATA = 'testext_mynamehere_metadata'
 REDSHIFT_SCHEMA_SIS = 'testext_mynamehere_sis'
 
 # S3 key prefix. Since the testext bucket is shared between users, choose something unique.

--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -35,6 +35,7 @@ from nessie.jobs.generate_intermediate_tables import GenerateIntermediateTables
 from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 from nessie.jobs.sync_file_to_s3 import SyncFileToS3
 from nessie.lib.http import tolerant_jsonify
+from nessie.lib.metadata import update_canvas_sync_status
 
 
 @app.route('/api/job/create_canvas_schema', methods=['POST'])
@@ -82,7 +83,10 @@ def sync_file_to_s3():
     key = data and data.get('key')
     if not key:
         raise BadRequestError('Required "key" parameter missing.')
-    job_started = SyncFileToS3(url=url, key=key).run_async()
+    canvas_sync_job_id = data and data.get('canvas_sync_job_id')
+    if canvas_sync_job_id:
+        update_canvas_sync_status(canvas_sync_job_id, key, 'received')
+    job_started = SyncFileToS3(url=url, key=key, canvas_sync_job_id=canvas_sync_job_id).run_async()
     return respond_with_status(job_started)
 
 

--- a/nessie/externals/redshift.py
+++ b/nessie/externals/redshift.py
@@ -70,10 +70,12 @@ def _execute(sql, operation, **kwargs):
     """
     result = None
     try:
+        params = None
         if kwargs:
+            params = kwargs.pop('params', None)
             sql = psycopg2.sql.SQL(sql).format(**kwargs)
         with get_cursor(operation) as cursor:
-            cursor.execute(sql)
+            cursor.execute(sql, params)
             if operation == 'read':
                 result = [row for row in cursor]
             else:

--- a/nessie/jobs/background_job.py
+++ b/nessie/jobs/background_job.py
@@ -57,6 +57,7 @@ def resolve_sql_template(sql_filename):
         'redshift_schema_boac': app.config['REDSHIFT_SCHEMA_BOAC'],
         'redshift_schema_canvas': app.config['REDSHIFT_SCHEMA_CANVAS'],
         'redshift_schema_intermediate': app.config['REDSHIFT_SCHEMA_INTERMEDIATE'],
+        'redshift_schema_metadata': app.config['REDSHIFT_SCHEMA_METADATA'],
         'redshift_schema_sis': app.config['REDSHIFT_SCHEMA_SIS'],
         'redshift_iam_role': app.config['REDSHIFT_IAM_ROLE'],
         'loch_s3_canvas_data_path_today': s3_prefix + get_s3_canvas_daily_path(),

--- a/nessie/jobs/sync_file_to_s3.py
+++ b/nessie/jobs/sync_file_to_s3.py
@@ -27,17 +27,32 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """Logic for file sync to S3."""
 
 
+from botocore.exceptions import ClientError, ConnectionError
 from flask import current_app as app
 from nessie.externals import s3
 from nessie.jobs.background_job import BackgroundJob
+from nessie.lib.metadata import create_canvas_snapshot, update_canvas_sync_status
 
 
 class SyncFileToS3(BackgroundJob):
 
-    def run(self, url, key):
+    def run(self, url, key, canvas_sync_job_id=None):
+        if canvas_sync_job_id:
+            update_canvas_sync_status(canvas_sync_job_id, key, 'started')
         if s3.object_exists(key):
             app.logger.info(f'Key {key} exists, skipping upload')
+            if canvas_sync_job_id:
+                update_canvas_sync_status(canvas_sync_job_id, key, 'duplicate')
             return False
         else:
             app.logger.info(f'Key {key} does not exist, starting upload')
-            return s3.upload_from_url(url, key)
+            try:
+                response = s3.upload_from_url(url, key)
+                if response and canvas_sync_job_id:
+                    update_canvas_sync_status(canvas_sync_job_id, key, 'complete')
+                    create_canvas_snapshot(key, size=response.get('ContentLength'))
+                return True
+            except (ClientError, ConnectionError, ValueError) as e:
+                if canvas_sync_job_id:
+                    update_canvas_sync_status(canvas_sync_job_id, key, 'error', details=str(e))
+                return False

--- a/nessie/lib/metadata.py
+++ b/nessie/lib/metadata.py
@@ -1,0 +1,78 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+from flask import current_app as app
+from nessie.externals import redshift, s3
+import psycopg2.sql
+
+
+def create_canvas_sync_status(job_id, filename, canvas_table, source_url):
+    sql = """INSERT INTO {schema}.canvas_sync_job_status
+               (job_id, filename, canvas_table, source_url, status, created_at, updated_at)
+               VALUES (%s, %s, %s, %s, 'created', current_timestamp, current_timestamp)
+               """
+    return redshift.execute(
+        sql,
+        params=(job_id, filename, canvas_table, source_url),
+        schema=_schema(),
+    )
+
+
+def update_canvas_sync_status(job_id, key, status, **kwargs):
+    filename = key.split('/')[-1]
+    destination_url = s3.build_s3_url(key, credentials=False)
+    details = kwargs.get('details')
+    sql = """UPDATE {schema}.canvas_sync_job_status
+             SET destination_url=%s, status=%s, details=%s, updated_at=current_timestamp
+             WHERE job_id=%s AND filename=%s"""
+    return redshift.execute(
+        sql,
+        params=(destination_url, status, details, job_id, filename),
+        schema=_schema(),
+    )
+
+
+def create_canvas_snapshot(key, size):
+    canvas_table, filename = key.split('/')[-2:]
+    url = s3.build_s3_url(key, credentials=False)
+    sql = """INSERT INTO {schema}.canvas_synced_snapshots
+             (filename, canvas_table, url, size, created_at)
+             VALUES (%s, %s, %s, %s, current_timestamp)"""
+    return redshift.execute(
+        sql,
+        params=(filename, canvas_table, url, size),
+        schema=_schema(),
+    )
+
+
+def delete_canvas_snapshots(keys):
+    filenames = [key.split('/')[-1] for key in keys]
+    sql = 'UPDATE {schema}.canvas_synced_snapshots SET deleted_at=current_timestamp WHERE filename IN %s'
+    return redshift.execute(sql, params=[tuple(filenames)], schema=_schema())
+
+
+def _schema():
+    return psycopg2.sql.Identifier(app.config['REDSHIFT_SCHEMA_METADATA'])

--- a/nessie/sql_templates/create_metadata_schema.template.sql
+++ b/nessie/sql_templates/create_metadata_schema.template.sql
@@ -1,0 +1,63 @@
+/**
+ * Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+CREATE SCHEMA IF NOT EXISTS {redshift_schema_metadata};
+
+CREATE TABLE IF NOT EXISTS {redshift_schema_metadata}.canvas_sync_job_status
+(
+    job_id VARCHAR NOT NULL,
+    filename VARCHAR NOT NULL,
+    canvas_table VARCHAR NOT NULL,
+    source_url VARCHAR NOT NULL,
+    destination_url VARCHAR,
+    # Possible 'status' values:
+    # - 'created': the master node has identified a source file in Canvas and will dispatch a sync job
+    # - 'received': the worker node has received the dispatch request
+    # - 'started': the worker node has started the sync job in a background thread
+    # - 'complete': the worker node has completed the file upload to S3
+    # - 'duplicate': the worker node has found a duplicate file in S3 and will not upload
+    # - 'error': an error occurred.
+    status VARCHAR NOT NULL,
+    # Further details on job status. Currently used only for errors.
+    details VARCHAR,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    # Primary key constraints are not enforced by Redshift but are used in query planning.
+    # https://docs.aws.amazon.com/redshift/latest/dg/t_Defining_constraints.html
+    PRIMARY KEY (job_id, filename)
+)
+DISTKEY (job_id)
+INTERLEAVED SORTKEY (job_id, filename);
+
+CREATE TABLE IF NOT EXISTS {redshift_schema_metadata}.canvas_synced_snapshots
+(
+    filename VARCHAR NOT NULL,
+    canvas_table VARCHAR NOT NULL,
+    url VARCHAR NOT NULL,
+    size BIGINT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    deleted_at TIMESTAMP
+)
+SORTKEY (filename);

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ https://github.com/ets-berkeley-edu/smart_open/archive/master.zip
 # For testing
 
 https://github.com/gabrielfalcao/HTTPretty/archive/master.zip
-moto==1.3.1
+moto==1.3.3
 pytest==3.3.0
 pytest-flask==0.10.0
 tox==2.9.1

--- a/tests/test_externals/test_redshift.py
+++ b/tests/test_externals/test_redshift.py
@@ -28,7 +28,7 @@ from nessie.externals import redshift
 from nessie.jobs.background_job import resolve_sql_template
 import psycopg2.sql
 import pytest
-from tests.util import capture_app_logs
+from tests.util import capture_app_logs, override_config
 
 
 @pytest.fixture()
@@ -52,9 +52,9 @@ class TestRedshift:
     def test_connection_error_handling(self, app, caplog):
         """Handles and logs connection errors."""
         with capture_app_logs(app):
-            app.config['REDSHIFT_HOST'] = 'H.C. Earwicker'
-            redshift.execute('SELECT 1')
-            assert 'could not translate host name "H.C. Earwicker" to address' in caplog.text
+            with override_config(app, 'REDSHIFT_HOST', 'H.C. Earwicker'):
+                redshift.execute('SELECT 1')
+                assert 'could not translate host name "H.C. Earwicker" to address' in caplog.text
 
     @pytest.mark.testext
     def test_schema_creation_drop(self, app, caplog, ensure_drop_schema):

--- a/tests/test_jobs/test_sync_canvas_snapshots.py
+++ b/tests/test_jobs/test_sync_canvas_snapshots.py
@@ -23,7 +23,7 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from nessie.externals import s3
+from nessie.externals import redshift, s3
 from nessie.jobs.sync_canvas_snapshots import delete_objects_with_prefix, SyncCanvasSnapshots
 import pytest
 from tests.util import capture_app_logs
@@ -32,7 +32,7 @@ from tests.util import capture_app_logs
 class TestSyncCanvasSnapshots:
     """Sync Canvas snapshots job."""
 
-    def test_sync_canvas_snapshots(self, app, caplog):
+    def test_sync_canvas_snapshots(self, app, metadata_db, caplog):
         """Dispatches a complete sync job against fixtures."""
         with capture_app_logs(app):
             # The cleanup job requires an S3 connection. Since our mock S3 library (moto) doesn't play well with our
@@ -41,6 +41,22 @@ class TestSyncCanvasSnapshots:
             assert 'Dispatched S3 sync of snapshot quiz_dim-00000-0ab80c7c.gz' in caplog.text
             assert 'Dispatched S3 sync of snapshot requests-00098-b14782f5.gz' in caplog.text
             assert '311 successful dispatches, 0 failures' in caplog.text
+
+            schema = app.config['REDSHIFT_SCHEMA_METADATA']
+            results = redshift.fetch(f'SELECT count(*) FROM {schema}.canvas_sync_job_status')
+            assert results[0].count == 311
+            results = redshift.fetch(f'SELECT DISTINCT status FROM {schema}.canvas_sync_job_status')
+            assert len(results) == 1
+            assert results[0].status == 'created'
+            results = redshift.fetch(f'SELECT * FROM {schema}.canvas_sync_job_status LIMIT 1')
+            assert results[0].job_id
+            assert results[0].filename == 'account_dim-00000-5eb7ee9e.gz'
+            assert results[0].canvas_table == 'account_dim'
+            assert 'account_dim/part-00505-5c40f1f3-b611-4f64-a007-67b775e984fe.c000.txt.gz' in results[0].source_url
+            assert results[0].destination_url is None
+            assert results[0].details is None
+            assert results[0].created_at
+            assert results[0].updated_at
 
     @pytest.mark.testext
     def test_remove_obsolete_files(self, app, caplog, cleanup_s3):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-323

Here's a first stab at a coordinated metadata store. We have two tables: one to store results per sync job, per file, and one to serve as an inventory of actual files currently in S3.

Much of this PR is supporting architecture for test coverage. We use a local Postgres to mock out the Redshift interface; that database needs to be created for local test runs as described in the README. Let's see what Travis thinks...