### PR TITLE
LA-443 Plug intermittent test failure with fixture

### DIFF
--- a/fixtures/sonnet_xlv.html
+++ b/fixtures/sonnet_xlv.html
@@ -1,0 +1,20 @@
+<HTML><HEAD><TITLE>Sonnet XLV</TITLE></HEAD>
+<BODY><H1>Sonnet XLV</H1>
+
+<BLOCKQUOTE>The other two, slight air and purging fire,<BR>
+Are both with thee, wherever I abide;<BR>
+The first my thought, the other my desire,<BR>
+These present-absent with swift motion slide.<BR>
+For when these quicker elements are gone<BR>
+In tender embassy of love to thee,<BR>
+My life, being made of four, with two alone<BR>
+Sinks down to death, oppress'd with melancholy;<BR>
+Until life's composition be recured<BR>
+By those swift messengers return'd from thee,<BR>
+Who even but now come back again, assured<BR>
+Of thy fair health, recounting it to me:<BR>
+  This told, I joy; but then no longer glad,<BR>
+  I send them back again and straight grow sad.<BR>
+</BLOCKQUOTE>
+
+</BODY></HTML>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-443

Moto, our mock AWS library, prefers HTTP mocks to come by way of `responses` rather than `httpretty`. It would be nice to get all our HTTP mocks consistent, but this stops the intermittent failure for now.