### PR TITLE
LA-428 Verify external schemas after drop and recreation

### DIFF
--- a/nessie/jobs/create_canvas_schema.py
+++ b/nessie/jobs/create_canvas_schema.py
@@ -29,7 +29,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from flask import current_app as app
 from nessie.externals import redshift
-from nessie.jobs.background_job import BackgroundJob, resolve_sql_template
+from nessie.jobs.background_job import BackgroundJob, resolve_sql_template, verify_external_schema
 
 
 class CreateCanvasSchema(BackgroundJob):
@@ -39,7 +39,7 @@ class CreateCanvasSchema(BackgroundJob):
         resolved_ddl = resolve_sql_template('create_canvas_schema.template.sql')
         if redshift.execute_ddl_script(resolved_ddl):
             app.logger.info(f'Canvas schema creation job completed.')
-            return True
+            return verify_external_schema(app.config['REDSHIFT_SCHEMA_CANVAS'], resolved_ddl)
         else:
             app.logger.error(f'Canvas schema creation job failed.')
             return False

--- a/nessie/jobs/create_sis_schema.py
+++ b/nessie/jobs/create_sis_schema.py
@@ -30,7 +30,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import json
 from flask import current_app as app
 from nessie.externals import redshift, s3
-from nessie.jobs.background_job import BackgroundJob, get_s3_sis_daily_path, resolve_sql_template
+from nessie.jobs.background_job import BackgroundJob, get_s3_sis_daily_path, resolve_sql_template, verify_external_schema
 
 
 class CreateSisSchema(BackgroundJob):
@@ -44,7 +44,7 @@ class CreateSisSchema(BackgroundJob):
         resolved_ddl = resolve_sql_template('create_sis_schema.template.sql')
         if redshift.execute_ddl_script(resolved_ddl):
             app.logger.info(f'SIS schema creation job completed.')
-            return True
+            return verify_external_schema(app.config['REDSHIFT_SCHEMA_SIS'], resolved_ddl)
         else:
             app.logger.error(f'SIS schema creation job failed.')
             return False


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/LA-428

If anything is amiss, returning `False` from these jobs will abort subsequent jobs and leave BOAC's materialized views intact.