### PR TITLE
NS-77, intermediate_schema::active_student_enrollments gets canvas_enrollment_id

### DIFF
--- a/nessie/sql_templates/create_boac_schema.template.sql
+++ b/nessie/sql_templates/create_boac_schema.template.sql
@@ -219,11 +219,8 @@ AS (
             ON ase.canvas_user_id = {redshift_schema_intermediate}.users.canvas_id
         JOIN {redshift_schema_canvas}.course_dim cd
             ON ase.canvas_course_id = cd.canvas_id
-        JOIN {redshift_schema_canvas}.enrollment_fact enr
-            ON enr.user_id = {redshift_schema_intermediate}.users.global_id
-              AND enr.course_id = cd.id
         JOIN {redshift_schema_canvas}.course_score_fact csf
-            ON csf.enrollment_id = enr.enrollment_id
+            ON csf.enrollment_id = ase.canvas_enrollment_id
     GROUP BY
         ase.uid,
         ase.canvas_user_id,

--- a/nessie/sql_templates/create_intermediate_schema.template.sql
+++ b/nessie/sql_templates/create_intermediate_schema.template.sql
@@ -184,6 +184,7 @@ AS (
         {redshift_schema_intermediate}.users.uid AS uid,
         {redshift_schema_intermediate}.users.canvas_id AS canvas_user_id,
         {redshift_schema_canvas}.course_dim.canvas_id AS canvas_course_id,
+        {redshift_schema_canvas}.enrollment_dim.id AS canvas_enrollment_id,
         {redshift_schema_canvas}.enrollment_dim.last_activity_at AS last_activity_at,
         /*
          * MIN ordering happens to match our desired precedence when reconciling enrollment status among multiple
@@ -212,5 +213,6 @@ AS (
         {redshift_schema_intermediate}.users.uid,
         {redshift_schema_intermediate}.users.canvas_id,
         {redshift_schema_canvas}.course_dim.canvas_id,
+        {redshift_schema_canvas}.enrollment_dim.id,
         {redshift_schema_canvas}.enrollment_dim.last_activity_at
 );


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-77

I generated `johncrossman_*` schemata on `data_loch_dev`: 

![image](https://user-images.githubusercontent.com/7606442/40571848-0fa5d008-6055-11e8-83e5-6d6a04b60346.png)


Ran SQL, against `course_enrollments`, via BOAC to verify:
```
SELECT, canvas_user_id, current_score
FROM johncrossman_boac_analytics.course_enrollments
WHERE course_id=1468432
ORDER BY canvas_user_id
```
