### PR TITLE
BOAC-917 A student without scores might lack a course_score_fact row

### DIFF
--- a/nessie/sql_templates/create_boac_schema.template.sql
+++ b/nessie/sql_templates/create_boac_schema.template.sql
@@ -219,7 +219,7 @@ AS (
             ON ase.canvas_user_id = {redshift_schema_intermediate}.users.canvas_id
         JOIN {redshift_schema_canvas}.course_dim cd
             ON ase.canvas_course_id = cd.canvas_id
-        JOIN {redshift_schema_canvas}.course_score_fact csf
+        LEFT JOIN {redshift_schema_canvas}.course_score_fact csf
             ON csf.enrollment_id = ase.canvas_enrollment_id
     GROUP BY
         ase.uid,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-917

When that happens, we still need to return `last_activity_at` and `sis_enrollment_status`.