### PR TITLE
NS-89 Job schedule API endpoint

### DIFF
--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -34,10 +34,28 @@ from nessie.jobs.create_sis_schema import CreateSisSchema
 from nessie.jobs.generate_boac_analytics import GenerateBoacAnalytics
 from nessie.jobs.generate_intermediate_tables import GenerateIntermediateTables
 from nessie.jobs.resync_canvas_snapshots import ResyncCanvasSnapshots
+from nessie.jobs.scheduling import get_scheduler
 from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 from nessie.jobs.sync_file_to_s3 import SyncFileToS3
 from nessie.lib.http import tolerant_jsonify
 from nessie.lib.metadata import update_canvas_sync_status
+
+
+@app.route('/api/job/schedule', methods=['GET'])
+def job_schedule():
+    sched = get_scheduler()
+    response = []
+    for job in sched.get_jobs():
+        if hasattr(job.args[1], '__iter__'):
+            job_desc = [arg.__name__ for arg in job.args[1]]
+        else:
+            job_desc = job.args[1].__name__
+        response.append({
+            'job': job_desc,
+            'trigger': str(job.trigger),
+            'nextRun': str(job.next_run_time),
+        })
+    return tolerant_jsonify(response)
 
 
 @app.route('/api/job/create_canvas_schema', methods=['POST'])

--- a/nessie/jobs/scheduling.py
+++ b/nessie/jobs/scheduling.py
@@ -30,6 +30,13 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from apscheduler.schedulers.background import BackgroundScheduler
 
 
+sched = None
+
+
+def get_scheduler():
+    return sched
+
+
 def initialize_job_schedules(app):
     from nessie.jobs.create_canvas_schema import CreateCanvasSchema
     from nessie.jobs.create_sis_schema import CreateSisSchema
@@ -38,7 +45,8 @@ def initialize_job_schedules(app):
     from nessie.jobs.resync_canvas_snapshots import ResyncCanvasSnapshots
     from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 
-    if app.config['JOB_SCHEDULING_ENABLED']:
+    global sched
+    if app.config['JOB_SCHEDULING_ENABLED'] and sched is None:
         sched = BackgroundScheduler()
         schedule_job(app, sched, 'JOB_SYNC_CANVAS_SNAPSHOTS', SyncCanvasSnapshots)
         schedule_job(app, sched, 'JOB_RESYNC_CANVAS_SNAPSHOTS', ResyncCanvasSnapshots)

--- a/tests/test_api/test_job_controller.py
+++ b/tests/test_api/test_job_controller.py
@@ -26,6 +26,8 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import base64
 import json
+import re
+
 import pytest
 
 
@@ -125,3 +127,16 @@ class TestJobControllerSyncFileToS3:
         )
         assert response.status_code == 200
         assert response.json['status'] == 'started'
+
+
+class TestJobControllerSchedule:
+
+    def test_job_schedule(self, app, client):
+        """Returns job schedule based on default config values."""
+        jobs = client.get('/api/job/schedule').json
+        assert len(jobs) == 3
+        assert jobs[0]['job'] == 'SyncCanvasSnapshots'
+        assert jobs[1]['job'] == 'ResyncCanvasSnapshots'
+        assert jobs[2]['job'] == ['CreateCanvasSchema', 'CreateSisSchema', 'GenerateIntermediateTables', 'GenerateBoacAnalytics']
+        assert jobs[2]['trigger'] == "cron[hour='2', minute='0']"
+        assert re.match('\d{4}-\d{2}-\d{2} 02:00:00', jobs[2]['nextRun'])


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-89

It's no `crontab -l`, but I hope it serves. A global scheduler object gives us something to grab when needed, though it probably won't be enough to prevent multiple scheduler instances in different processes. @raydavis's suggestion in https://jira.ets.berkeley.edu/jira/browse/NS-107 of a Postgres advisory lock seems like a good way to handle it.