### PR TITLE
NS-89 POST endpoint to manage job schedules

### DIFF
--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -34,31 +34,10 @@ from nessie.jobs.create_sis_schema import CreateSisSchema
 from nessie.jobs.generate_boac_analytics import GenerateBoacAnalytics
 from nessie.jobs.generate_intermediate_tables import GenerateIntermediateTables
 from nessie.jobs.resync_canvas_snapshots import ResyncCanvasSnapshots
-from nessie.jobs.scheduling import get_scheduler, PG_ADVISORY_LOCK_IDS
 from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 from nessie.jobs.sync_file_to_s3 import SyncFileToS3
 from nessie.lib.http import tolerant_jsonify
 from nessie.lib.metadata import update_canvas_sync_status
-from nessie.models.util import get_granted_lock_ids
-
-
-@app.route('/api/job/schedule', methods=['GET'])
-def job_schedule():
-    sched = get_scheduler()
-    lock_ids = get_granted_lock_ids()
-
-    def job_dict(job):
-        job_components = job.args[0]
-        if not hasattr(job_components, '__iter__'):
-            job_components = [job_components]
-        return {
-            'id': job.id.lower(),
-            'components': [c.__name__ for c in job_components],
-            'trigger': str(job.trigger),
-            'nextRun': str(job.next_run_time),
-            'locked': (PG_ADVISORY_LOCK_IDS.get(job.id) in lock_ids),
-        }
-    return tolerant_jsonify([job_dict(job) for job in sched.get_jobs()])
 
 
 @app.route('/api/job/create_canvas_schema', methods=['POST'])

--- a/nessie/api/schedule_controller.py
+++ b/nessie/api/schedule_controller.py
@@ -1,0 +1,78 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+from flask import current_app as app, request
+from nessie.api.auth_helper import auth_required
+from nessie.api.errors import BadRequestError
+from nessie.jobs.scheduling import get_scheduler, PG_ADVISORY_LOCK_IDS
+from nessie.lib.http import tolerant_jsonify
+from nessie.models.util import get_granted_lock_ids
+
+
+def job_to_dict(job):
+    lock_ids = get_granted_lock_ids()
+    job_components = job.args[0]
+    if not hasattr(job_components, '__iter__'):
+        job_components = [job_components]
+    return {
+        'id': job.id.lower(),
+        'components': [c.__name__ for c in job_components],
+        'trigger': str(job.trigger),
+        'nextRun': str(job.next_run_time) if job.next_run_time else None,
+        'locked': (PG_ADVISORY_LOCK_IDS.get(job.id) in lock_ids),
+    }
+
+
+@app.route('/api/schedule', methods=['GET'])
+def get_job_schedule():
+    sched = get_scheduler()
+    return tolerant_jsonify([job_to_dict(job) for job in sched.get_jobs()])
+
+
+@app.route('/api/schedule/<job_id>', methods=['POST'])
+@auth_required
+def update_job_schedule(job_id):
+    try:
+        args = request.get_json(force=True)
+    except Exception as e:
+        raise BadRequestError(str(e))
+    sched = get_scheduler()
+    job_id = job_id.upper()
+    job = sched.get_job(job_id)
+    if not job:
+        raise BadRequestError(f'No job found for job id: {job_id}')
+    # If JSON properties are present, they will be evaluated by APScheduler's cron trigger API.
+    # https://apscheduler.readthedocs.io/en/latest/modules/triggers/cron.html#module-apscheduler.triggers.cron
+    if args:
+        try:
+            job.reschedule(trigger='cron', **args)
+        except Exception as e:
+            raise BadRequestError(f'Error rescheduling job: {e}')
+    # Passing a empty JSON object will suspend this job's schedule.
+    else:
+        job.pause()
+    job = sched.get_job(job_id)
+    return tolerant_jsonify(job_to_dict(job))

--- a/nessie/jobs/scheduling.py
+++ b/nessie/jobs/scheduling.py
@@ -59,7 +59,7 @@ def initialize_job_schedules(_app):
     app = _app
 
     global sched
-    if app.config['JOB_SCHEDULING_ENABLED'] and sched is None:
+    if app.config['JOB_SCHEDULING_ENABLED']:
         db_jobstore = SQLAlchemyJobStore(url=app.config['SQLALCHEMY_DATABASE_URI'], tablename='apscheduler_jobs')
         sched = BackgroundScheduler(jobstores={'default': db_jobstore})
         schedule_job(sched, 'JOB_SYNC_CANVAS_SNAPSHOTS', SyncCanvasSnapshots)

--- a/nessie/routes.py
+++ b/nessie/routes.py
@@ -31,6 +31,7 @@ def register_routes(app):
     """Register app routes."""
     # Register API routes.
     import nessie.api.job_controller
+    import nessie.api.schedule_controller
     import nessie.api.status_controller
 
     # Register error handlers.

--- a/tests/test_api/test_schedule_controller.py
+++ b/tests/test_api/test_schedule_controller.py
@@ -1,0 +1,127 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+import re
+
+import pytest
+from tests.util import credentials, post_basic_auth
+
+
+@pytest.fixture()
+def scheduler(app):
+    """Re-initialize job scheduler from configs on teardown so that changes don't persist."""
+    yield
+    from nessie.jobs.scheduling import initialize_job_schedules
+    initialize_job_schedules(app)
+
+
+class TestGetSchedule:
+
+    def test_get_schedule(self, app, client):
+        """Returns job schedule based on default config values."""
+        jobs = client.get('/api/schedule').json
+        assert len(jobs) == 3
+        assert jobs[0]['id'] == 'job_sync_canvas_snapshots'
+        assert jobs[0]['components'] == ['SyncCanvasSnapshots']
+        assert jobs[0]['locked'] is False
+        assert jobs[1]['id'] == 'job_resync_canvas_snapshots'
+        assert jobs[1]['components'] == ['ResyncCanvasSnapshots']
+        assert jobs[1]['locked'] is False
+        assert jobs[2]['id'] == 'job_generate_all_tables'
+        assert jobs[2]['components'] == ['CreateCanvasSchema', 'CreateSisSchema', 'GenerateIntermediateTables', 'GenerateBoacAnalytics']
+        assert jobs[2]['locked'] is False
+        assert jobs[2]['trigger'] == "cron[hour='2', minute='0']"
+        assert re.match('\d{4}-\d{2}-\d{2} 02:00:00', jobs[2]['nextRun'])
+
+
+class TestUpdateSchedule:
+
+    def test_no_authentication(self, app, client):
+        """Refuses a request with no authentication."""
+        response = client.post('/api/schedule/job_sync_canvas_snapshots')
+        assert response.status_code == 401
+
+    def test_bad_authentication(self, app, client):
+        """Refuse a request with bad authentication."""
+        response = post_basic_auth(
+            client,
+            '/api/schedule/job_sync_canvas_snapshots',
+            ('arrant', 'knave'),
+        )
+        assert response.status_code == 401
+
+    def test_unknown_job_id(self, app, client):
+        """Handles unknown job id."""
+        response = post_basic_auth(
+            client,
+            '/api/schedule/job_churn_butter',
+            credentials(app),
+        )
+        assert response.status_code == 400
+
+    def test_unknown_cron_param(self, app, client):
+        """Handles unknown cron params."""
+        response = post_basic_auth(
+            client,
+            '/api/schedule/job_sync_canvas_snapshots',
+            credentials(app),
+            {'h': 'j'},
+        )
+        assert response.status_code == 400
+
+    def test_job_reschedule(self, app, client, scheduler):
+        """Reschedules a job."""
+        response = post_basic_auth(
+            client,
+            '/api/schedule/job_sync_canvas_snapshots',
+            credentials(app),
+            {'hour': 12, 'minute': 30},
+        )
+        assert response.status_code == 200
+        assert response.json['trigger'] == "cron[hour='12', minute='30']"
+        assert '12:30:00' in response.json['nextRun']
+
+    def test_job_pause_resume(self, app, client, scheduler):
+        """Pauses and resumes a job."""
+        response = post_basic_auth(
+            client,
+            '/api/schedule/job_sync_canvas_snapshots',
+            credentials(app),
+            {},
+        )
+        assert response.status_code == 200
+        assert response.json['trigger'] == "cron[hour='1', minute='0']"
+        assert response.json['nextRun'] is None
+
+        response = post_basic_auth(
+            client,
+            '/api/schedule/job_sync_canvas_snapshots',
+            credentials(app),
+            {'hour': 1, 'minute': 0},
+        )
+        assert response.status_code == 200
+        assert response.json['trigger'] == "cron[hour='1', minute='0']"
+        assert '01:00:00' in response.json['nextRun']

--- a/tests/util.py
+++ b/tests/util.py
@@ -23,7 +23,9 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+import base64
 from contextlib import contextmanager
+import json
 import logging
 
 import boto3
@@ -62,3 +64,13 @@ def override_config(app, key, value):
     app.config[key] = value
     yield
     app.config[key] = old_value
+
+
+def credentials(app):
+    return (app.config['WORKER_USERNAME'], app.config['WORKER_PASSWORD'])
+
+
+def post_basic_auth(client, path, credentials, data=None):
+    auth_string = bytes(credentials[0] + ':' + credentials[1], 'utf-8')
+    encoded_credentials = base64.b64encode(auth_string).decode('utf-8')
+    return client.post(path, data=json.dumps(data), headers={'Authorization': 'Basic ' + encoded_credentials})


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-89

Example usage:

`curl -u username:password -d '{"hour": 12, "minute": "30"}' https://app-master-prod.ets-berkeley-nessie.net/api/schedule/job_sync_canvas_snapshots`

To turn the job off:

`curl -u username:password -d '{}' http://app-master-prod.ets-berkeley-nessie.net/api/schedule/job_sync_canvas_snapshots`