### PR TITLE
NS-82, create_asc_schema uses JSON files uploaded to S3 by ASC import job

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -86,6 +86,7 @@ LOCH_S3_CANVAS_DATA_PATH_CURRENT_TERM = 'canvas/path/to/current/term'
 LOCH_S3_CANVAS_DATA_PATH_DAILY = 'canvas/path/to/daily'
 LOCH_S3_CANVAS_DATA_PATH_HISTORICAL = 'canvas/path/to/historical'
 
+LOCH_S3_ASC_DATA_PATH = 'asc/path'
 LOCH_S3_SIS_DATA_PATH = 'sis/path'
 
 LOCH_CANVAS_DATA_REQUESTS_CUTOFF_DATE = '20180101'
@@ -102,6 +103,7 @@ REDSHIFT_USER = 'username'
 
 REDSHIFT_IAM_ROLE = 'iam role'
 
+REDSHIFT_SCHEMA_ASC = 'ASC schema name'
 REDSHIFT_SCHEMA_BOAC = 'BOAC schema name'
 REDSHIFT_SCHEMA_CANVAS = 'Canvas schema name'
 REDSHIFT_SCHEMA_INTERMEDIATE = 'Intermediate schema name'

--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -29,6 +29,7 @@ from flask import current_app as app, request
 from nessie.api.auth_helper import auth_required
 from nessie.api.errors import BadRequestError
 from nessie.jobs.background_job import ChainedBackgroundJob
+from nessie.jobs.create_asc_schema import CreateAscSchema
 from nessie.jobs.create_canvas_schema import CreateCanvasSchema
 from nessie.jobs.create_sis_schema import CreateSisSchema
 from nessie.jobs.generate_boac_analytics import GenerateBoacAnalytics
@@ -45,6 +46,13 @@ from nessie.lib.metadata import update_canvas_sync_status
 @auth_required
 def create_canvas_schema():
     job_started = CreateCanvasSchema().run_async()
+    return respond_with_status(job_started)
+
+
+@app.route('/api/job/create_asc_schema', methods=['POST'])
+@auth_required
+def create_asc_schema():
+    job_started = CreateAscSchema().run_async()
     return respond_with_status(job_started)
 
 

--- a/nessie/jobs/background_job.py
+++ b/nessie/jobs/background_job.py
@@ -54,16 +54,24 @@ def get_s3_sis_daily_path(cutoff=datetime.now()):
     return app.config['LOCH_S3_SIS_DATA_PATH'] + '/daily/' + today_hash + '-' + today
 
 
+def get_s3_asc_daily_path(cutoff=datetime.now()):
+    today = localize_datetime(cutoff).strftime('%Y-%m-%d')
+    today_hash = hashlib.md5(today.encode('utf-8')).hexdigest()
+    return app.config['LOCH_S3_ASC_DATA_PATH'] + '/daily/' + today_hash + '-' + today
+
+
 def resolve_sql_template(sql_filename):
     """Our DDL template files are simple enough to use standard Python string formatting."""
     s3_prefix = 's3://' + app.config['LOCH_S3_BUCKET'] + '/'
     template_data = {
+        'redshift_schema_asc': app.config['REDSHIFT_SCHEMA_ASC'],
         'redshift_schema_boac': app.config['REDSHIFT_SCHEMA_BOAC'],
         'redshift_schema_canvas': app.config['REDSHIFT_SCHEMA_CANVAS'],
         'redshift_schema_intermediate': app.config['REDSHIFT_SCHEMA_INTERMEDIATE'],
         'redshift_schema_metadata': app.config['REDSHIFT_SCHEMA_METADATA'],
         'redshift_schema_sis': app.config['REDSHIFT_SCHEMA_SIS'],
         'redshift_iam_role': app.config['REDSHIFT_IAM_ROLE'],
+        'loch_s3_asc_data_path': s3_prefix + app.config['LOCH_S3_ASC_DATA_PATH'],
         'loch_s3_canvas_data_path_today': s3_prefix + get_s3_canvas_daily_path(),
         'loch_s3_canvas_data_path_historical': s3_prefix + app.config['LOCH_S3_CANVAS_DATA_PATH_HISTORICAL'],
         'loch_s3_canvas_data_path_current_term': s3_prefix + app.config['LOCH_S3_CANVAS_DATA_PATH_CURRENT_TERM'],

--- a/nessie/jobs/create_asc_schema.py
+++ b/nessie/jobs/create_asc_schema.py
@@ -1,0 +1,46 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from flask import current_app as app
+from nessie.externals import redshift
+from nessie.jobs.background_job import BackgroundJob, resolve_sql_template, verify_external_schema
+
+
+"""Logic for ASC schema creation job."""
+
+
+class CreateAscSchema(BackgroundJob):
+
+    def run(self):
+        app.logger.info(f'Starting ASC schema creation job...')
+        external_schema = app.config['REDSHIFT_SCHEMA_ASC']
+        redshift.drop_external_schema(external_schema)
+        resolved_ddl = resolve_sql_template('create_asc_schema.template.sql')
+        if redshift.execute_ddl_script(resolved_ddl):
+            app.logger.info(f'ASC schema creation job completed.')
+            return verify_external_schema(external_schema, resolved_ddl)
+        else:
+            app.logger.error(f'ASC schema creation job failed.')
+            return False

--- a/nessie/lib/db.py
+++ b/nessie/lib/db.py
@@ -1,0 +1,49 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from contextlib import contextmanager
+import psycopg2
+import psycopg2.extras
+import psycopg2.sql
+
+
+@contextmanager
+def get_psycopg_cursor(operation='read', **kwargs):
+    connection = None
+    cursor = None
+    if operation == 'write':
+        cursor_factory = None
+    else:
+        cursor_factory = psycopg2.extras.NamedTupleCursor
+    try:
+        connection = psycopg2.connect(**kwargs)
+        # Autocommit is required for EXTERNAL TABLE creation and deletion.
+        connection.autocommit = True
+        yield connection.cursor(cursor_factory=cursor_factory)
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if connection is not None:
+            connection.close()

--- a/nessie/sql_templates/create_asc_schema.template.sql
+++ b/nessie/sql_templates/create_asc_schema.template.sql
@@ -1,0 +1,54 @@
+/**
+ * Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+--------------------------------------------------------------------
+-- CREATE EXTERNAL SCHEMA
+--------------------------------------------------------------------
+
+CREATE EXTERNAL SCHEMA {redshift_schema_asc}
+FROM data catalog
+DATABASE '{redshift_schema_asc}'
+IAM_ROLE '{redshift_iam_role}'
+CREATE EXTERNAL DATABASE IF NOT EXISTS;
+
+--------------------------------------------------------------------
+-- External Tables
+--------------------------------------------------------------------
+
+-- courses
+CREATE EXTERNAL TABLE {redshift_schema_asc}.athletics(
+    group_code VARCHAR,
+    group_name VARCHAR,
+    team_code VARCHAR,
+    team_name VARCHAR
+)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES (
+  'separatorChar' = ',',
+  'quoteChar' = '\"',
+  'escapeChar' = '\\'
+)
+STORED AS TEXTFILE
+LOCATION '{loch_s3_asc_data_path}/athletics.json';


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-82

* `get_psycopg_cursor` is now a shared db util because _psycopg2_ is necessary to run SQL: `COPY (SELECT ROW_TO_JSON...)` during ASC import.
* `create_asc_schema.template.sql` is unfinished; verifying Redshift schema creation is next step.