### PR TITLE
BOAC-982, if ASC API is down then log a proper error message

### DIFF
--- a/nessie/externals/asc_athletes_api.py
+++ b/nessie/externals/asc_athletes_api.py
@@ -32,8 +32,9 @@ from nessie.lib.mockingbird import fixture
 def get_asc_feed():
     response = _get_asc_feed_response()
     if not response or not hasattr(response, 'json'):
-        app.logger.error(f'Bad response from ASC Athletes API: {response}')
-        return None
+        error = f'ASC API unexpected response: {response}'
+        app.logger.error(error)
+        return {'error': error}
     # The API responds with a hash whose values correspond to the rows of a CSV or TSV.
     asc_hash = response.json()
     return [r for r in asc_hash.values()]

--- a/nessie/jobs/import_asc_athletes.py
+++ b/nessie/jobs/import_asc_athletes.py
@@ -44,8 +44,11 @@ class ImportAscAthletes(BackgroundJob):
     def run(self, force=False):
         app.logger.info(f'ASC import: Fetch team and student athlete data from ASC API')
         api_results = get_asc_feed()
-        if api_results is None:
-            app.logger.error('ASC import: ASC API returned zero results')
+        if 'error' in api_results:
+            app.logger.error('ASC import: Error from external API: {}'.format(api_results['error']))
+            status = False
+        elif not api_results:
+            app.logger.error('ASC import: API returned zero students')
             status = False
         else:
             last_sync_date = _get_last_sync_date()


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-982

"API returned zero results" is wrong if ASC API is down.