### PR TITLE
NS-81 Job to kick off BOAC cache refresh

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -57,6 +57,9 @@ ASC_ATHLETES_API_URL = 'https://secreturl.berkeley.edu/intensives.php?AcadYr=201
 ASC_ATHLETES_API_KEY = 'secret'
 ASC_THIS_ACAD_YR = '2017-18'
 
+BOAC_API_KEY = 'Regents of the University of California'
+BOAC_CACHE_REFRESH_URL = 'https://ets-boac.example.com/api/refresh_me'
+
 CANVAS_DATA_API_KEY = 'some key'
 CANVAS_DATA_API_SECRET = 'some secret'
 CANVAS_DATA_HOST = 'foo.instructure.com'
@@ -79,6 +82,7 @@ JOB_SCHEDULING_ENABLED = True
 JOB_SYNC_CANVAS_SNAPSHOTS = {'hour': 1, 'minute': 0}
 JOB_RESYNC_CANVAS_SNAPSHOTS = {'hour': 1, 'minute': 40}
 JOB_GENERATE_ALL_TABLES = {'hour': 2, 'minute': 00}
+JOB_REFRESH_BOAC_CACHE = {'hour': 3, 'minute': 00}
 
 LDAP_HOST = 'nds-test.berkeley.edu'
 LDAP_BIND = 'mybind'

--- a/nessie/externals/boac.py
+++ b/nessie/externals/boac.py
@@ -1,0 +1,41 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+"""BOAC auth API."""
+
+from flask import current_app as app
+from nessie.lib import http
+
+
+def kickoff_refresh():
+    return authorized_request(app.config['BOAC_CACHE_REFRESH_URL'])
+
+
+def authorized_request(url):
+    # The more typical underscored "app_key" header will be stripped out by the AWS load balancer.
+    # A hyphened "app-key" header passes through.
+    auth_headers = {'app-key': app.config['BOAC_API_KEY']}
+    return http.request(url, auth_headers)

--- a/nessie/jobs/refresh_boac_cache.py
+++ b/nessie/jobs/refresh_boac_cache.py
@@ -1,0 +1,44 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+"""Logic for BOAC cache refresh kickoff."""
+
+
+from flask import current_app as app
+from nessie.externals import boac
+from nessie.jobs.background_job import BackgroundJob
+
+
+class RefreshBoacCache(BackgroundJob):
+
+    def run(self):
+        app.logger.info(f'Starting BOAC refresh kickoff...')
+        if boac.kickoff_refresh():
+            app.logger.info(f'BOAC refresh kickoff completed.')
+            return True
+        else:
+            app.logger.error(f'BOAC refresh kickoff returned an error.')
+            return False

--- a/nessie/jobs/scheduling.py
+++ b/nessie/jobs/scheduling.py
@@ -40,6 +40,7 @@ PG_ADVISORY_LOCK_IDS = {
     'JOB_SYNC_CANVAS_SNAPSHOTS': 1000,
     'JOB_RESYNC_CANVAS_SNAPSHOTS': 2000,
     'JOB_GENERATE_ALL_TABLES': 3000,
+    'JOB_REFRESH_BOAC_CACHE': 4000,
 }
 
 
@@ -52,6 +53,7 @@ def initialize_job_schedules(_app, force=False):
     from nessie.jobs.create_sis_schema import CreateSisSchema
     from nessie.jobs.generate_boac_analytics import GenerateBoacAnalytics
     from nessie.jobs.generate_intermediate_tables import GenerateIntermediateTables
+    from nessie.jobs.refresh_boac_cache import RefreshBoacCache
     from nessie.jobs.resync_canvas_snapshots import ResyncCanvasSnapshots
     from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 
@@ -76,6 +78,7 @@ def initialize_job_schedules(_app, force=False):
             ],
             force,
         )
+        schedule_job(sched, 'JOB_REFRESH_BOAC_CACHE', RefreshBoacCache, force)
 
 
 def add_job(sched, job_func, job_arg, job_id, force=False):

--- a/tests/test_api/test_schedule_controller.py
+++ b/tests/test_api/test_schedule_controller.py
@@ -43,7 +43,7 @@ class TestGetSchedule:
     def test_get_schedule(self, app, client):
         """Returns job schedule based on default config values."""
         jobs = client.get('/api/schedule').json
-        assert len(jobs) == 3
+        assert len(jobs) == 4
         assert jobs[0]['id'] == 'job_sync_canvas_snapshots'
         assert jobs[0]['components'] == ['SyncCanvasSnapshots']
         assert jobs[0]['locked'] is False
@@ -55,6 +55,9 @@ class TestGetSchedule:
         assert jobs[2]['locked'] is False
         assert jobs[2]['trigger'] == "cron[hour='2', minute='0']"
         assert re.match('\d{4}-\d{2}-\d{2} 02:00:00', jobs[2]['nextRun'])
+        assert jobs[3]['id'] == 'job_refresh_boac_cache'
+        assert jobs[3]['components'] == ['RefreshBoacCache']
+        assert jobs[3]['locked'] is False
 
 
 class TestUpdateSchedule:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-81

If this PR passes muster, there are a couple of operational steps associated with deploy:
- Add BOAC_API_KEY, BOAC_CACHE_REFRESH_URL, and JOB_REFRESH_BOAC_CACHE keys to nessie-master-dev config;
- Remove the corresponding cronjob on junction-dev so that Nessie can take over.