### PR TITLE
NS-131 Background job to generate student profile tables in Redshift

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -122,6 +122,7 @@ REDSHIFT_SCHEMA_COE = 'COE schema name'
 REDSHIFT_SCHEMA_INTERMEDIATE = 'Intermediate schema name'
 REDSHIFT_SCHEMA_METADATA = 'Metadata schema name'
 REDSHIFT_SCHEMA_SIS = 'SIS schema name'
+REDSHIFT_SCHEMA_STUDENTS = 'Student schema name'
 
 STUDENT_API_ID = 'secretid'
 STUDENT_API_KEY = 'secretkey'

--- a/nessie/jobs/background_job.py
+++ b/nessie/jobs/background_job.py
@@ -77,7 +77,7 @@ def get_s3_sis_daily_path(cutoff=datetime.now()):
     return app.config['LOCH_S3_SIS_DATA_PATH'] + '/daily/' + today_hash + '-' + today
 
 
-def resolve_sql_template(sql_filename):
+def resolve_sql_template(sql_filename, **kwargs):
     """Our DDL template files are simple enough to use standard Python string formatting."""
     s3_prefix = 's3://' + app.config['LOCH_S3_BUCKET'] + '/'
     template_data = {
@@ -89,6 +89,7 @@ def resolve_sql_template(sql_filename):
         'redshift_schema_intermediate': app.config['REDSHIFT_SCHEMA_INTERMEDIATE'],
         'redshift_schema_metadata': app.config['REDSHIFT_SCHEMA_METADATA'],
         'redshift_schema_sis': app.config['REDSHIFT_SCHEMA_SIS'],
+        'redshift_schema_student': app.config['REDSHIFT_SCHEMA_STUDENT'],
         'redshift_iam_role': app.config['REDSHIFT_IAM_ROLE'],
         'loch_s3_asc_data_path': s3_prefix + get_s3_asc_daily_path(),
         'loch_s3_calnet_data_path': s3_prefix + get_s3_calnet_daily_path(),
@@ -98,6 +99,8 @@ def resolve_sql_template(sql_filename):
         'loch_s3_coe_data_path': s3_prefix + get_s3_coe_daily_path(),
         'loch_s3_sis_data_path': s3_prefix + app.config['LOCH_S3_SIS_DATA_PATH'],
     }
+    # Kwargs may be passed in to modify default template data.
+    template_data.update(kwargs)
     with open(app.config['BASE_DIR'] + f'/nessie/sql_templates/{sql_filename}', encoding='utf-8') as file:
         template_string = file.read()
     return template_string.format(**template_data)

--- a/nessie/jobs/generate_merged_profiles.py
+++ b/nessie/jobs/generate_merged_profiles.py
@@ -1,0 +1,150 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+"""Logic for merged student profile generation."""
+
+
+from itertools import groupby
+import json
+import operator
+
+from flask import current_app as app
+from nessie.externals import redshift
+from nessie.jobs.background_job import BackgroundJob, resolve_sql_template
+from nessie.lib import queries
+from nessie.merged.sis_profile import get_merged_sis_profile
+import psycopg2.sql
+
+
+class GenerateMergedProfiles(BackgroundJob):
+
+    destination_schema = app.config['REDSHIFT_SCHEMA_STUDENT']
+    destination_schema_identifier = psycopg2.sql.Identifier(destination_schema)
+    staging_schema = destination_schema + '_staging'
+    staging_schema_identifier = psycopg2.sql.Identifier(staging_schema)
+
+    def run(self):
+        """Loop through all records stored in the Calnet external schema and write merged profile data to the internal student schema."""
+        app.logger.info(f'Starting merged profile generation job...')
+        staging_schema_ddl = resolve_sql_template('create_student_schema.template.sql', redshift_schema_student=self.staging_schema)
+        if not redshift.execute_ddl_script(staging_schema_ddl):
+            app.logger.error('Failed to create staging tables for merged profiles.')
+            return False
+
+        calnet_profiles = redshift.fetch(
+            'SELECT ldap_uid, sid, first_name, last_name FROM {calnet_schema}.persons',
+            calnet_schema=psycopg2.sql.Identifier(app.config['REDSHIFT_SCHEMA_CALNET']),
+        )
+        for sid, profile_group in groupby(calnet_profiles, operator.itemgetter('sid')):
+            self.generate_merged_profile(sid, list(profile_group)[0])
+
+        for table in ['student_profiles', 'student_academic_status', 'student_majors']:
+            result = redshift.fetch(
+                'SELECT COUNT(*) FROM {schema}.{table}',
+                schema=self.staging_schema_identifier,
+                table=psycopg2.sql.Identifier(table),
+            )
+            if result and result[0] and result[0]['count']:
+                count = result[0]['count']
+                app.logger.info(f'Verified population of staging table {table} ({count} rows).')
+            else:
+                app.logger.error(f'Failed to verify population of staging table {table}: aborting job.')
+                return False
+
+        redshift.execute('BEGIN TRANSACTION')
+        recreate_schema_ddl = resolve_sql_template('create_student_schema.template.sql')
+        if not redshift.execute_ddl_script(recreate_schema_ddl):
+            app.logger.error('Failed to recreate schema for merged profiles.')
+            redshift.execute('ROLLBACK TRANSACTION')
+            return False
+
+        for table in ['student_profiles', 'student_academic_status', 'student_majors']:
+            result = redshift.execute(
+                'INSERT INTO {schema}.{table} (SELECT * FROM {staging_schema}.{table})',
+                schema=self.destination_schema_identifier,
+                staging_schema=self.staging_schema_identifier,
+                table=psycopg2.sql.Identifier(table),
+            )
+            if not result:
+                app.logger.error(f'Failed to populate table {self.destination_schema}.{table} from staging schema.')
+                redshift.execute('ROLLBACK TRANSACTION')
+                return False
+
+        redshift.execute('DROP SCHEMA {staging_schema} CASCADE', staging_schema=self.staging_schema_identifier)
+        transaction_result = redshift.execute('COMMIT TRANSACTION')
+        if not transaction_result:
+            app.logger.error(f'Final transaction commit failed for {self.destination_schema}.')
+            return False
+        return True
+
+    def generate_merged_profile(self, sid, calnet_profile):
+        uid = calnet_profile.get('ldap_uid')
+        if not uid:
+            return
+        canvas_user_result = queries.get_user_for_uid(uid)
+        canvas_profile = canvas_user_result[0] if canvas_user_result else {}
+        sis_profile = get_merged_sis_profile(sid)
+        merged_profile = {
+            'sid': sid,
+            'uid': uid,
+            'firstName': calnet_profile.get('first_name'),
+            'lastName': calnet_profile.get('last_name'),
+            'name': ' '.join([calnet_profile.get('first_name'), calnet_profile.get('last_name')]),
+            'canvasUserId': canvas_profile.get('canvas_id'),
+            'canvasUserName': canvas_profile.get('name'),
+            'sisProfile': sis_profile,
+        }
+        result = redshift.execute(
+            'INSERT INTO {schema}.student_profiles (sid, profile) VALUES (%s, %s)',
+            params=(sid, json.dumps(merged_profile)),
+            schema=self.staging_schema_identifier,
+        )
+        if not result:
+            app.logger.error(f'Insert failed into {self.staging_schema}.student_profiles: (sid={sid})')
+
+        if not sis_profile:
+            return
+
+        level = sis_profile.get('level', {}).get('code')
+        gpa = sis_profile.get('cumulativeGPA')
+        units = sis_profile.get('cumulativeUnits')
+        result = redshift.execute(
+            'INSERT INTO {schema}.student_academic_status (sid, level, gpa, units) VALUES (%s, %s, %s, %s)',
+            params=(sid, level, gpa, units),
+            schema=self.staging_schema_identifier,
+        )
+        if not result:
+            app.logger.error(f'Insert failed into {self.staging_schema}.student_academic_status:\
+                              (sid={sid}, level={level}, gpa={gpa}, units={units})')
+        for plan in sis_profile.get('plans', []):
+            major = plan['description']
+            result = redshift.execute(
+                'INSERT INTO {schema}.student_majors (sid, major) VALUES (%s, %s)',
+                params=(sid, major),
+                schema=self.staging_schema_identifier,
+            )
+            if not result:
+                app.logger.error(f'Insert failed into {self.staging_schema}.student_majors: (sid={sid}, major={major})')

--- a/nessie/lib/berkeley.py
+++ b/nessie/lib/berkeley.py
@@ -31,6 +31,131 @@ from flask import current_app as app
 
 """A utility module collecting logic specific to the Berkeley campus."""
 
+# This is not a complete mapping:
+#  - Not all SIS-defined academic plans map to a single Degree Programs page.
+#  - Not all Degree Programs pages map to a single SIS-defined academic plan.
+#  - An unknown number of obsolete academic plan descriptions are still active
+#    from before the CS era.
+ACADEMIC_PLAN_TO_DEGREE_PROGRAM_PAGE = {
+    'African American Studies': 'african-american-studies',
+    'American Studies': 'american-studies',
+    'Anthropology': 'anthropology',
+    'Applied Mathematics': 'applied-mathematics',
+    'Architecture': 'architecture',
+    'Art': 'art-practice',
+    'Asian Am & Asian Diasp': 'asian-american-diaspora-studies',
+    'Asian Studies': 'asian-studies-multi-area',
+    'Astrophysics': 'astrophysics',
+    'BioE\/MSE Joint Major': 'bioengineering-materials-science-engineering-joint-major',
+    'Bioengineering': 'bioengineering',
+    'Buddhist Studies': 'buddhism',
+    'Business Administration': 'business-administration',
+    'Celtic Studies': 'celtic-studies',
+    'Chem Eng\/MSE Joint Major': 'chemical-engineering-materials-science-joint-major',
+    'Chem Eng\/NE Joint Major': 'chemical-engineering-nuclear-joint-major',
+    'Chemical Biology': 'chemical-biology',
+    'Chemical Engineering': 'chemical-engineering',
+    'Chemistry': 'chemistry',
+    'Chicano Studies': 'chicano-latino-studies',
+    'Chinese Language': 'chinese-language',
+    'City & Regional Planning': 'city-planning',
+    'Civil & Environmental Eng': 'environmental-engineering',
+    'Civil Engineering': 'civil-engineering',
+    'Classical Civilizations': 'classical-civilizations',
+    'Classical Languages': 'classical-languages',
+    'Cognitive Science': 'cognitive-science',
+    'Comparative Literature': 'comparative-literature',
+    'Computer Science': 'computer-science',
+    'Conserv & Resource Stds': 'conservation-resource-studies',
+    'Dance & Perf Studies': 'dance-performance-studies',
+    'Demography': 'demography',
+    'Development Studies': 'development-studies',
+    'Dutch Studies': 'dutch-studies',
+    'Earth & Planetary Science': 'earth-planetary-science',
+    'Economics': 'economics',
+    'Education': 'education',
+    'Electrical Eng & Comp Sci': 'electrical-engineering-computer-sciences',
+    'Energy & Resources': 'energy-resources',
+    'Energy Engineering': 'energy-engineering',
+    'Eng Math & Statistics': 'engineering-math-statistics',
+    'Engineering Physics': 'engineering-physics',
+    'English': 'english',
+    'Environ Econ & Policy': 'environmental-economics-policy',
+    'Environmental Eng Science': 'environmental-engineering-science',
+    'Environmental Sciences': 'environmental-sciences',
+    'Ethnic Studies': 'ethnic-studies',
+    'Film': 'film',
+    'Forestry & Natural Res': 'forestry-natural-resources',
+    'French': 'french',
+    'Gender & Womens Studies': 'gender-womens-studies',
+    'Genetics & Plant Biology': 'genetics-plant-biology',
+    'Geography': 'geography',
+    'Geology': 'geology',
+    'Geophysics': 'geophysics',
+    'German': 'german',
+    'Global Studies': 'global-studies',
+    'Greek': 'greek',
+    'Hispanic Lang': 'hispanic-languages-linguistics-bilingualism',
+    'History of Art': 'art-history',
+    'History': 'history',
+    'Industrial Eng & Ops Rsch': 'industrial-engineering-operations-research',
+    'Integrative Biology': 'integrative-biology',
+    'Interdisciplinary Studies': 'interdisciplinary-studies',
+    'Italian': 'italian-studies',
+    'Japanese Language': 'japanese-language',
+    'Jewish Studies': 'jewish-studies',
+    'Journalism': 'journalism',
+    'Landscape Architecture': 'landscape-architecture',
+    'Latin American Studies': 'latin-american-studies',
+    'Latin': 'latin',
+    'Legal Studies': 'legal-studies',
+    'Linguistics': 'linguistics',
+    'Materials Science & Eng': 'materials-science-engineering',
+    'Mathematics': 'mathematics',
+    'MCB-Biochem & Mol Biol': 'molecular-cell-biology-biochemistry',
+    'MCB-Cell & Dev Biology': 'molecular-cell-biology-developmental',
+    'MCB-Neurobiology': 'molecular-cell-biology-neurobiology',
+    'ME\/NE Joint Major': 'mechanical-engineering-nuclear',
+    'Mechanical Engineering': 'mechanical-engineering',
+    'Media Studies': 'media-studies',
+    'Medieval Studies': 'medieval-studies',
+    'Microbial Biology': 'microbial-biology',
+    'Middle Eastern Studies': 'middle-eastern-studies',
+    'Molecular Environ Biology': 'molecular-environmental-biology',
+    'MSE\/ME Joint Major': 'materials-science-engineering-mechanical-joint-major',
+    'MSE\/NE Joint Major': 'materials-science-engineering-nuclear-joint-major',
+    'Music': 'music',
+    'Native American Studies': 'native-american-studies',
+    'Near Eastern Studies': 'near-eastern-civilizations',
+    'Nuclear Engineering': 'nuclear-engineering',
+    'Nut Sci-Physio & Metabol': 'nutritional-science',
+    'Nutritional Sci-Toxicology': 'nutritional-science',
+    'Nutritional Science': 'nutritional-science',
+    'Peace & Conflict Studies': 'peace-conflict-studies',
+    'Philosophy': 'philosophy',
+    'Physics': 'physics',
+    'Political Economy': 'political-economy',
+    'Political Science': 'political-science',
+    'Psychology': 'psychology',
+    'Public Health': 'public-health',
+    'Public Policy': 'public-policy',
+    'Religious Studies': 'religious-studies',
+    'Rhetoric': 'rhetoric',
+    'Scandinavian': 'scandinavian',
+    'Science & Math Education': 'science-math-education',
+    'Slavic Lang & Lit': 'czech-polish-bosnian-croatian-serbian-language-literature',
+    'Social Welfare': 'socialwelfare',
+    'Society and Environment': 'society-environment',
+    'Sociology': 'sociology',
+    'South & SE Asian Studies': 'south-southeast-asian-studies',
+    'Span-Spanish Lang & Lit': 'languages-literatures-cultures-spanish-speaking-world',
+    'Spanish': 'languages-literatures-cultures-spanish-speaking-world',
+    'Statistics': 'statistics',
+    'Sustainable Environ Dsgn': 'sustainable-environmental-design',
+    'Theater & Perf Studies': 'theater-performance-studies',
+    'Urban Studies': 'urban-studies',
+}
+
 
 def reverse_terms_until(stop_term):
     term_name = app.config['CURRENT_TERM']
@@ -67,6 +192,17 @@ def term_name_for_sis_id(sis_id=None):
             '8': 'Fall',
         }
         return season_codes[sis_id[3:4]] + ' 20' + sis_id[1:3]
+
+
+def degree_program_url_for_major(plan_description):
+    matched = next(
+        (k for k in ACADEMIC_PLAN_TO_DEGREE_PROGRAM_PAGE.keys() if re.match(r'^' + re.escape(k) + r' (BA|BS)', plan_description)),
+        None,
+    )
+    if matched:
+        return f'http://guide.berkeley.edu/undergraduate/degree-programs/{ACADEMIC_PLAN_TO_DEGREE_PROGRAM_PAGE[matched]}/'
+    else:
+        return None
 
 
 def current_term_id():

--- a/nessie/merged/sis_profile.py
+++ b/nessie/merged/sis_profile.py
@@ -1,0 +1,145 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+import re
+from flask import current_app as app
+from nessie.externals import sis_degree_progress_api
+from nessie.externals import sis_student_api
+from nessie.lib.berkeley import degree_program_url_for_major, term_name_for_sis_id
+from nessie.lib.util import vacuum_whitespace
+
+
+def get_merged_sis_profile(csid):
+    sis_response = sis_student_api.get_student(csid)
+    if not sis_response:
+        return False
+
+    sis_profile = {}
+    merge_sis_profile_academic_status(sis_response, sis_profile)
+    merge_sis_profile_emails(sis_response, sis_profile)
+
+    # We have encountered at least one malformed Hub Student Profile feed in which the top-level
+    # 'names' key points to an embedded 'names' array rather than simply pointing to the array.
+    # See BOAC-362 for details.
+    try:
+        merge_sis_profile_names(sis_response, sis_profile)
+    except AttributeError as e:
+        app.logger.error(f'Hub Student API returned malformed response for SID {csid}')
+        app.logger.error(e)
+
+    merge_sis_profile_phones(sis_response, sis_profile)
+    if sis_profile['academicCareer'] == 'UGRD':
+        sis_profile['degreeProgress'] = sis_degree_progress_api.parsed_degree_progress(csid)
+
+    return sis_profile
+
+
+def merge_sis_profile_academic_status(sis_response, sis_profile):
+    # The Hub may return multiple academic statuses. We'll select the first status with a well-formed academic
+    # career that is not a concurrent enrollment.
+    academic_status = None
+    for status in sis_response.get('academicStatuses', []):
+        career_code = status.get('currentRegistration', {}).get('academicCareer', {}).get('code')
+        if career_code and career_code != 'UCBX':
+            academic_status = status
+            break
+    if not academic_status:
+        return
+
+    sis_profile['cumulativeGPA'] = academic_status.get('cumulativeGPA', {}).get('average')
+    sis_profile['level'] = academic_status.get('currentRegistration', {}).get('academicLevel', {}).get('level')
+    sis_profile['termsInAttendance'] = academic_status.get('termsInAttendance')
+    sis_profile['academicCareer'] = academic_status.get('currentRegistration', {}).get('academicCareer', {}).get('code')
+
+    matriculation_term_name = academic_status.get('studentCareer', {}).get('matriculation', {}).get('term', {}).get('name')
+    if matriculation_term_name and re.match('\A2\d{3} (?:Spring|Summer|Fall)\Z', matriculation_term_name):
+        # "2015 Fall" to "Fall 2015"
+        sis_profile['matriculation'] = ' '.join(reversed(matriculation_term_name.split()))
+
+    for units in academic_status.get('cumulativeUnits', []):
+        if units.get('type', {}).get('code') == 'Total':
+            sis_profile['cumulativeUnits'] = units.get('unitsCumulative')
+            break
+
+    merge_sis_profile_plans(academic_status, sis_profile)
+
+
+def merge_sis_profile_emails(sis_response, sis_profile):
+    primary_email = None
+    campus_email = None
+    for email in sis_response.get('emails', []):
+        if email.get('primary'):
+            primary_email = email.get('emailAddress')
+            break
+        elif email.get('type', {}).get('code') == 'CAMP':
+            campus_email = email.get('emailAddress')
+    sis_profile['emailAddress'] = primary_email or campus_email
+
+
+def merge_sis_profile_names(sis_response, sis_profile):
+    for name in sis_response.get('names', []):
+        code = name.get('type', {}).get('code')
+        if code == 'PRF':
+            sis_profile['preferredName'] = vacuum_whitespace(name.get('formattedName'))
+        elif code == 'PRI':
+            sis_profile['primaryName'] = vacuum_whitespace(name.get('formattedName'))
+        if 'primaryName' in sis_profile and 'preferredName' in sis_profile:
+            break
+
+
+def merge_sis_profile_phones(sis_response, sis_profile):
+    phones_by_code = {
+        phone.get('type', {}).get('code'): phone.get('number')
+        for phone in sis_response.get('phones', [])
+    }
+    sis_profile['phoneNumber'] = phones_by_code.get('CELL') or phones_by_code.get('LOCL') or phones_by_code.get('HOME')
+
+
+def merge_sis_profile_plans(academic_status, sis_profile):
+    sis_profile['plans'] = []
+    for student_plan in academic_status.get('studentPlans', []):
+        academic_plan = student_plan.get('academicPlan', {})
+        # SIS majors come in five flavors.
+        if academic_plan.get('type', {}).get('code') not in ['MAJ', 'SS', 'SP', 'HS', 'CRT']:
+            continue
+        plan = academic_plan.get('plan', {})
+        major = plan.get('description')
+        plan_feed = {
+            'degreeProgramUrl': degree_program_url_for_major(major),
+            'description': major,
+        }
+        # Find the latest expected graduation term from any plan.
+        expected_graduation_term = student_plan.get('expectedGraduationTerm', {}).get('id')
+        if expected_graduation_term and expected_graduation_term > sis_profile.get('expectedGraduationTerm', {}).get('id', '0'):
+            sis_profile['expectedGraduationTerm'] = {
+                'id': expected_graduation_term,
+                'name': term_name_for_sis_id(expected_graduation_term),
+            }
+        # Add program unless plan code indicates undeclared.
+        if plan.get('code') != '25000U':
+            program = student_plan.get('academicPlan', {}).get('academicProgram', {}).get('program', {})
+            plan_feed['program'] = program.get('description')
+        sis_profile['plans'].append(plan_feed)

--- a/nessie/sql_templates/create_student_schema.template.sql
+++ b/nessie/sql_templates/create_student_schema.template.sql
@@ -1,0 +1,53 @@
+/**
+ * Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+DROP SCHEMA IF EXISTS {redshift_schema_student} CASCADE;
+CREATE SCHEMA {redshift_schema_student};
+
+CREATE TABLE {redshift_schema_student}.student_profiles
+(
+    sid VARCHAR NOT NULL,
+    profile VARCHAR(max) NOT NULL
+)
+DISTKEY (sid)
+SORTKEY (sid);
+
+CREATE TABLE {redshift_schema_student}.student_academic_status
+(
+    sid VARCHAR NOT NULL,
+    level VARCHAR(2),
+    gpa DECIMAL(4,3),
+    units DECIMAL (4,1)
+)
+DISTKEY (units)
+INTERLEAVED SORTKEY (level, gpa, units);
+
+CREATE TABLE {redshift_schema_student}.student_majors
+(
+    sid VARCHAR NOT NULL,
+    major VARCHAR NOT NULL
+)
+DISTKEY (major)
+SORTKEY (major);

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -1,0 +1,64 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+from nessie.lib import berkeley
+
+
+class TestBerkeleySisTermIdForName:
+    """Term name to SIS id translation."""
+
+    def test_sis_term_id_for_name(self):
+        """Handles well-formed term names."""
+        assert berkeley.sis_term_id_for_name('Spring 2015') == '2152'
+        assert berkeley.sis_term_id_for_name('Summer 2016') == '2165'
+        assert berkeley.sis_term_id_for_name('Fall 2017') == '2178'
+
+    def test_unparseable_term_name(self):
+        """Returns None for unparseable term names."""
+        assert berkeley.sis_term_id_for_name('Winter 2061') is None
+        assert berkeley.sis_term_id_for_name('Default Term') is None
+
+    def test_missing_term_name(self):
+        """Returns None for missing term names."""
+        assert berkeley.sis_term_id_for_name(None) is None
+
+
+class TestBerkeleyDegreeProgramUrl:
+
+    def test_major_with_known_link(self):
+        assert berkeley.degree_program_url_for_major('English BA') == \
+            'http://guide.berkeley.edu/undergraduate/degree-programs/english/'
+        assert berkeley.degree_program_url_for_major('Peace & Conflict Studies BA') == \
+            'http://guide.berkeley.edu/undergraduate/degree-programs/peace-conflict-studies/'
+        assert berkeley.degree_program_url_for_major('History BA') == \
+            'http://guide.berkeley.edu/undergraduate/degree-programs/history/'
+        assert berkeley.degree_program_url_for_major('History of Art BA') == \
+            'http://guide.berkeley.edu/undergraduate/degree-programs/art-history/'
+
+    def test_major_without_a_link(self):
+        assert berkeley.degree_program_url_for_major('English for Billiards Players MS') is None
+        assert berkeley.degree_program_url_for_major('Altaic Language BA') is None
+        assert berkeley.degree_program_url_for_major('Entomology BS') is None

--- a/tests/test_lib/test_util.py
+++ b/tests/test_lib/test_util.py
@@ -24,32 +24,12 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 
-import inspect
-
-from flask import current_app as app
-import pytz
+from nessie.lib import util
 
 
-"""Generic utilities."""
+class TestUtil:
+    """Generic utilities."""
 
-
-def fill_pattern_from_args(pattern, func, *args, **kw):
-    return pattern.format(**get_args_dict(func, *args, **kw))
-
-
-def get_args_dict(func, *args, **kw):
-    arg_names = inspect.getfullargspec(func)[0]
-    resp = dict(zip(arg_names, args))
-    resp.update(kw)
-    return resp
-
-
-def localize_datetime(dt):
-    return dt.astimezone(pytz.timezone(app.config['TIMEZONE']))
-
-
-def vacuum_whitespace(_str):
-    """Collapse multiple-whitespace sequences into a single space; remove leading and trailing whitespace."""
-    if not _str:
-        return None
-    return ' '.join(_str.split())
+    def test_vacuum_whitespace(self):
+        """Cleans up leading, trailing, and repeated whitespace."""
+        assert util.vacuum_whitespace('  Firstname    Lastname   ') == 'Firstname Lastname'

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -24,32 +24,15 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 
-import inspect
-
-from flask import current_app as app
-import pytz
+from nessie.merged.sis_profile import get_merged_sis_profile
+import pytest
 
 
-"""Generic utilities."""
+@pytest.mark.usefixtures('db_session')
+class TestSisProfile:
+    """Test SIS profile."""
 
-
-def fill_pattern_from_args(pattern, func, *args, **kw):
-    return pattern.format(**get_args_dict(func, *args, **kw))
-
-
-def get_args_dict(func, *args, **kw):
-    arg_names = inspect.getfullargspec(func)[0]
-    resp = dict(zip(arg_names, args))
-    resp.update(kw)
-    return resp
-
-
-def localize_datetime(dt):
-    return dt.astimezone(pytz.timezone(app.config['TIMEZONE']))
-
-
-def vacuum_whitespace(_str):
-    """Collapse multiple-whitespace sequences into a single space; remove leading and trailing whitespace."""
-    if not _str:
-        return None
-    return ' '.join(_str.split())
+    def test_skips_concurrent_academic_status(self, app):
+        """Skips concurrent academic status."""
+        profile = get_merged_sis_profile('11667051')
+        assert profile['academicCareer'] == 'UGRD'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-131

Let's see how this flies. We loop through all sids in our Calnet stash, create merged profiles and output results to three internal Redshift tables: one with a big JSON payload and two others with extracted queryable values. (I expect that these queries will run somewhat slow compared to Postgres, but our future selves can sort that out.)

Results for our athlete population can be inspected in nessie_dev under the student_pk_test schema.

If this seems workable, the next steps would be to do something similar with student enrollment terms and try to fill out the skimpy test coverage.