### PR TITLE
NS-133 Internal schema containing ASC athletic profiles

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -115,6 +115,7 @@ REDSHIFT_USER = 'username'
 REDSHIFT_IAM_ROLE = 'iam role'
 
 REDSHIFT_SCHEMA_ASC = 'ASC schema name'
+REDSHIFT_SCHEMA_ASC_EXTERNAL = 'External ASC schema name'
 REDSHIFT_SCHEMA_BOAC = 'BOAC schema name'
 REDSHIFT_SCHEMA_CALNET = 'CalNet schema name'
 REDSHIFT_SCHEMA_CANVAS = 'Canvas schema name'

--- a/config/testext.py
+++ b/config/testext.py
@@ -9,6 +9,8 @@ REDSHIFT_USER = 'username'
 # Schema names. Since Redshift instances are shared between environments, choose something that can
 # be repeatedly created and torn down without conflicts.
 
+REDSHIFT_SCHEMA_ASC = 'testext_mynamehere_asc'
+REDSHIFT_SCHEMA_ASC_EXTERNAL = 'testext_mynamehere_asc_external'
 REDSHIFT_SCHEMA_BOAC = 'testext_mynamehere_boac'
 REDSHIFT_SCHEMA_CANVAS = 'testext_mynamehere_canvas'
 REDSHIFT_SCHEMA_INTERMEDIATE = 'testext_mynamehere_intermediate'

--- a/nessie/jobs/background_job.py
+++ b/nessie/jobs/background_job.py
@@ -81,6 +81,7 @@ def resolve_sql_template(sql_filename, **kwargs):
     s3_prefix = 's3://' + app.config['LOCH_S3_BUCKET'] + '/'
     template_data = {
         'redshift_schema_asc': app.config['REDSHIFT_SCHEMA_ASC'],
+        'redshift_schema_asc_external': app.config['REDSHIFT_SCHEMA_ASC_EXTERNAL'],
         'redshift_schema_boac': app.config['REDSHIFT_SCHEMA_BOAC'],
         'redshift_schema_calnet': app.config['REDSHIFT_SCHEMA_CALNET'],
         'redshift_schema_canvas': app.config['REDSHIFT_SCHEMA_CANVAS'],

--- a/nessie/jobs/create_asc_schema.py
+++ b/nessie/jobs/create_asc_schema.py
@@ -23,24 +23,65 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+from itertools import groupby
+import json
+import operator
+
 from flask import current_app as app
 from nessie.externals import redshift
 from nessie.jobs.background_job import BackgroundJob, resolve_sql_template, verify_external_schema
+import psycopg2
 
 
 """Logic for ASC schema creation job."""
+
+
+external_schema = app.config['REDSHIFT_SCHEMA_ASC_EXTERNAL']
+internal_schema = app.config['REDSHIFT_SCHEMA_ASC']
+internal_schema_identifier = psycopg2.sql.Identifier(internal_schema)
 
 
 class CreateAscSchema(BackgroundJob):
 
     def run(self):
         app.logger.info(f'Starting ASC schema creation job...')
-        external_schema = app.config['REDSHIFT_SCHEMA_ASC']
         redshift.drop_external_schema(external_schema)
         resolved_ddl = resolve_sql_template('create_asc_schema.template.sql')
+        # TODO This DDL drops and recreates the internal schema before the external schema is verified. We
+        # ought to set up proper staging in conjunction with verification. It's also possible that a persistent
+        # external schema isn't needed.
         if redshift.execute_ddl_script(resolved_ddl):
             app.logger.info(f'ASC schema creation job completed.')
-            return verify_external_schema(external_schema, resolved_ddl)
+            if not verify_external_schema(external_schema, resolved_ddl):
+                return False
         else:
             app.logger.error(f'ASC schema creation job failed.')
             return False
+        asc_rows = redshift.fetch(
+            'SELECT * FROM {schema}.students ORDER by sid',
+            schema=internal_schema_identifier,
+        )
+        for sid, rows_for_student in groupby(asc_rows, operator.itemgetter('sid')):
+            rows_for_student = list(rows_for_student)
+            athletics_profile = {
+                'athletics': [],
+                'inIntensiveCohort': rows_for_student[0]['intensive'],
+                'isActiveAsc': rows_for_student[0]['active'],
+                'statusAsc': rows_for_student[0]['status_asc'],
+            }
+            for row in rows_for_student:
+                athletics_profile['athletics'].append({
+                    'groupCode': row['group_code'],
+                    'groupName': row['group_name'],
+                    'name': row['group_name'],
+                    'teamCode': row['team_code'],
+                    'teamName': row['team_name'],
+                })
+            result = redshift.execute(
+                'INSERT INTO {schema}.student_profiles (sid, profile) VALUES (%s, %s)',
+                params=(sid, json.dumps(athletics_profile)),
+                schema=internal_schema_identifier,
+            )
+            if not result:
+                app.logger.error(f'Insert failed into {internal_schema}.student_profiles: (sid={sid})')
+        return True


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-133

Too many schemas? Check. No tests? Check. Outstanding TODOs? Check. But since this isn't yet a scheduled job, it's probably better to submit as is than leave it to languish on a working branch.

`student_profiles` contains precomposed JSON for quick serving.
`students` contains index columns suitable for querying on ASC attributes.

Output available for inspection under nessie_dev/boac_advising_asc_pk_test.