### PR TITLE
BOAC-1033 Better background job logging, failure tolerance

### DIFF
--- a/nessie/externals/sis_degree_progress_api.py
+++ b/nessie/externals/sis_degree_progress_api.py
@@ -34,20 +34,21 @@ import xmltodict
 
 
 def parsed_degree_progress(cs_id):
-    data = {}
     cs_feed = get_degree_progress(cs_id)
-    if cs_feed:
-        requirements_list = cs_feed.get('UC_AA_PROGRESS', {}).get('PROGRESSES', {}).get('PROGRESS', {}).get('REQUIREMENTS', {}).get('REQUIREMENT')
-        if requirements_list:
-            data['reportDate'] = cs_feed['UC_AA_PROGRESS']['PROGRESSES']['PROGRESS']['RPT_DATE']
-            data['requirements'] = {
-                'entryLevelWriting': {'name': 'Entry Level Writing'},
-                'americanHistory': {'name': 'American History'},
-                'americanInstitutions': {'name': 'American Institutions'},
-                'americanCultures': {'name': 'American Cultures'},
-            }
-            for req in requirements_list:
-                merge_requirement_status(data['requirements'], req)
+    if not cs_feed:
+        return cs_feed
+    data = {}
+    requirements_list = cs_feed.get('UC_AA_PROGRESS', {}).get('PROGRESSES', {}).get('PROGRESS', {}).get('REQUIREMENTS', {}).get('REQUIREMENT')
+    if requirements_list:
+        data['reportDate'] = cs_feed['UC_AA_PROGRESS']['PROGRESSES']['PROGRESS']['RPT_DATE']
+        data['requirements'] = {
+            'entryLevelWriting': {'name': 'Entry Level Writing'},
+            'americanHistory': {'name': 'American History'},
+            'americanInstitutions': {'name': 'American Institutions'},
+            'americanCultures': {'name': 'American Cultures'},
+        }
+        for req in requirements_list:
+            merge_requirement_status(data['requirements'], req)
     return data
 
 
@@ -93,7 +94,7 @@ def get_degree_progress(cs_id):
 def _get_degree_progress(cs_id, mock=None):
     url = http.build_url(app.config['DEGREE_PROGRESS_API_URL'], {'EMPLID': cs_id})
     with mock(url):
-        return http.request(url, auth=cs_api_auth())
+        return http.request(url, auth=cs_api_auth(), log_404s=False)
 
 
 def cs_api_auth():

--- a/nessie/externals/sis_enrollments_api.py
+++ b/nessie/externals/sis_enrollments_api.py
@@ -90,4 +90,4 @@ def authorized_request(url):
         'app_key': app.config['ENROLLMENTS_API_KEY'],
         'Accept': 'application/json',
     }
-    return http.request(url, auth_headers)
+    return http.request(url, auth_headers, log_404s=False)

--- a/nessie/jobs/background_job.py
+++ b/nessie/jobs/background_job.py
@@ -191,8 +191,17 @@ class BackgroundJob(object):
                 result = None
                 error = str(e)
             if self.status_logging_enabled:
-                status = 'succeeded' if result else 'failed'
-                update_background_job_status(job_id, status, error=error)
+                if result:
+                    status = 'succeeded'
+                    if isinstance(result, str):
+                        app.logger.info(result)
+                        details = result
+                    else:
+                        details = None
+                else:
+                    status = 'failed'
+                    details = error
+                update_background_job_status(job_id, status, details=details)
             return result
 
 

--- a/nessie/jobs/create_asc_schema.py
+++ b/nessie/jobs/create_asc_schema.py
@@ -92,5 +92,4 @@ class CreateAscSchema(BackgroundJob):
             app.logger.error('Error on Redshift copy: aborting job.')
             return False
 
-        app.logger.info('ASC schema creation complete.')
-        return True
+        return 'ASC schema creation complete.'

--- a/nessie/jobs/create_coe_schema.py
+++ b/nessie/jobs/create_coe_schema.py
@@ -96,5 +96,5 @@ class CreateCoeSchema(BackgroundJob):
         if not redshift.execute(query):
             app.logger.error('Error on Redshift copy: aborting job.')
             return False
-        app.logger.info(f'COE internal schema created.')
-        return True
+
+        return 'COE internal schema created.'

--- a/nessie/jobs/generate_boac_analytics.py
+++ b/nessie/jobs/generate_boac_analytics.py
@@ -38,8 +38,7 @@ class GenerateBoacAnalytics(BackgroundJob):
         app.logger.info(f'Starting BOAC analytics job...')
         resolved_ddl = resolve_sql_template('create_boac_schema.template.sql')
         if redshift.execute_ddl_script(resolved_ddl):
-            app.logger.info(f'BOAC analytics creation job completed.')
-            return True
+            return 'BOAC analytics creation job completed.'
         else:
             app.logger.error(f'BOAC analytics creation job failed.')
             return False

--- a/nessie/jobs/generate_intermediate_tables.py
+++ b/nessie/jobs/generate_intermediate_tables.py
@@ -38,8 +38,7 @@ class GenerateIntermediateTables(BackgroundJob):
         app.logger.info(f'Starting intermediate table generation job...')
         resolved_ddl = resolve_sql_template('create_intermediate_schema.template.sql')
         if redshift.execute_ddl_script(resolved_ddl):
-            app.logger.info(f'Intermediate table creation job completed.')
-            return True
+            return 'Intermediate table creation job completed.'
         else:
             app.logger.error(f'Intermediate table creation job failed.')
             return False

--- a/nessie/jobs/resync_canvas_snapshots.py
+++ b/nessie/jobs/resync_canvas_snapshots.py
@@ -47,8 +47,7 @@ class ResyncCanvasSnapshots(BackgroundJob):
         app.logger.info(f'Starting Canvas snapshot resync job... (id={job_id})')
         md = metadata.get_failures_from_last_sync()
         if not md['failures']:
-            app.logger.info(f"No failures found for job_id {md['job_id']}, skipping resync.")
-            return True
+            return f"No failures found for job_id {md['job_id']}, skipping resync."
         app.logger.info(f"Found {len(md['failures'])} failures for job_id {md['job_id']}, attempting resync.")
 
         failures = 0
@@ -86,5 +85,4 @@ class ResyncCanvasSnapshots(BackgroundJob):
                 app.logger.info('Dispatched S3 resync of snapshot ' + failure['filename'])
                 successes += 1
 
-        app.logger.info(f'Canvas snapshot resync job dispatched to workers ({successes} successful dispatches, {failures} failures).')
-        return True
+        return f'Canvas snapshot resync job dispatched to workers ({successes} successful dispatches, {failures} failures).'

--- a/nessie/jobs/sync_canvas_snapshots.py
+++ b/nessie/jobs/sync_canvas_snapshots.py
@@ -119,5 +119,4 @@ class SyncCanvasSnapshots(BackgroundJob):
             delete_result = delete_objects_with_prefix(requests_prefix, whitelist=current_snapshot_filenames)
             if not delete_result:
                 app.logger.error('Cleanup of obsolete snapshots failed.')
-        app.logger.info(f'Canvas snapshot sync job dispatched to workers ({success} successful dispatches, {failure} failures).')
-        return True
+        return f'Canvas snapshot sync job dispatched to workers ({success} successful dispatches, {failure} failures).'

--- a/nessie/lib/http.py
+++ b/nessie/lib/http.py
@@ -72,7 +72,7 @@ def get_next_page(response):
         return None
 
 
-def request(url, headers={}, method='get', auth=None, auth_params=None, data=None, **kwargs):
+def request(url, headers={}, method='get', auth=None, auth_params=None, data=None, log_404s=True, **kwargs):
     """Exception and error catching wrapper for outgoing HTTP requests.
 
     :param url:
@@ -99,9 +99,10 @@ def request(url, headers={}, method='get', auth=None, auth_params=None, data=Non
             urllib_logger.setLevel(saved_level)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
-        app.logger.error(e)
-        if hasattr(response, 'content'):
-            app.logger.error(response.content)
+        if not (hasattr(response, 'status_code') and response.status_code == 404 and not log_404s):
+            app.logger.error(e)
+            if hasattr(response, 'content'):
+                app.logger.error(response.content)
         return ResponseExceptionWrapper(e, response)
     else:
         return response

--- a/nessie/lib/metadata.py
+++ b/nessie/lib/metadata.py
@@ -114,15 +114,15 @@ def create_background_job_status(job_id):
     )
 
 
-def update_background_job_status(job_id, status, error=None):
-    if error:
-        error = error[:4096]
+def update_background_job_status(job_id, status, details=None):
+    if details:
+        details = details[:4096]
     sql = """UPDATE {schema}.background_job_status
-             SET status=%s, updated_at=current_timestamp, error=%s
+             SET status=%s, updated_at=current_timestamp, details=%s
              WHERE job_id=%s"""
     return redshift.execute(
         sql,
-        params=(status, error, job_id),
+        params=(status, details, job_id),
         schema=_schema(),
     )
 

--- a/nessie/merged/sis_profile.py
+++ b/nessie/merged/sis_profile.py
@@ -56,9 +56,8 @@ def get_merged_sis_profile(csid):
     if sis_profile['academicCareer'] == 'UGRD':
         dp_result = queries.get_sis_api_degree_progress(csid)
         degree_progress_api_feed = dp_result and dp_result[0] and json.loads(dp_result[0]['feed'])
-        if not degree_progress_api_feed:
-            return False
-        sis_profile['degreeProgress'] = degree_progress_api_feed
+        if degree_progress_api_feed:
+            sis_profile['degreeProgress'] = degree_progress_api_feed
 
     return sis_profile
 

--- a/nessie/sql_templates/create_metadata_schema.template.sql
+++ b/nessie/sql_templates/create_metadata_schema.template.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS {redshift_schema_metadata}.background_job_status
     instance_id VARCHAR,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,
-    error VARCHAR(4096),
+    details VARCHAR(4096),
     # Primary key constraints are not enforced by Redshift but are used in query planning.
     # https://docs.aws.amazon.com/redshift/latest/dg/t_Defining_constraints.html
     PRIMARY KEY (job_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def metadata_db(app):
         job_id VARCHAR NOT NULL,
         status VARCHAR NOT NULL,
         instance_id VARCHAR,
-        error VARCHAR(4096),
+        details VARCHAR(4096),
         created_at TIMESTAMP NOT NULL,
         updated_at TIMESTAMP NOT NULL
     )""")

--- a/tests/test_jobs/test_resync_canvas_snapshots.py
+++ b/tests/test_jobs/test_resync_canvas_snapshots.py
@@ -69,7 +69,7 @@ class TestResyncCanvasSnapshots:
             # mock HTTP library (httpretty), disable it for tests.
             # TODO resolve the incompatibility, possibly by switching from httpretty to responses.
             result = ResyncCanvasSnapshots().run_wrapped(cleanup=False)
-            assert result is True
+            assert 'Canvas snapshot resync job dispatched to workers' in result
             assert_background_job_status('resync')
             assert f"Dispatched S3 resync of snapshot {stalled['filename']}" in caplog.text
             assert f"Dispatched S3 resync of snapshot {errored['filename']}" in caplog.text

--- a/tests/test_jobs/test_sync_canvas_snapshots.py
+++ b/tests/test_jobs/test_sync_canvas_snapshots.py
@@ -39,7 +39,7 @@ class TestSyncCanvasSnapshots:
             # mock HTTP library (httpretty), disable it for tests.
             # TODO resolve the incompatibility, possibly by switching from httpretty to responses.
             result = SyncCanvasSnapshots().run_wrapped(cleanup=False)
-            assert result is True
+            assert 'Canvas snapshot sync job dispatched to workers' in result
             assert_background_job_status('sync')
             assert 'Dispatched S3 sync of snapshot quiz_dim-00000-0ab80c7c.gz' in caplog.text
             assert 'Dispatched S3 sync of snapshot requests-00098-b14782f5.gz' in caplog.text


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1033

- Use a staging table on API loops so that today's failed retrieval doesn't wipe out yesterday's success;
- Don't log 404s as errors for API loops which return 404s in the normal course of business;
- Fix a dumb bug that caused merged profile generation to fail if degree progress was missing;
- Both succeeded and failed jobs can return a status string which will be stored in the metadata table.