### PR TITLE
NS-168 Generate required schemas on startup if necessary

### DIFF
--- a/nessie/factory.py
+++ b/nessie/factory.py
@@ -29,7 +29,7 @@ from flask import Flask
 from nessie import db
 from nessie.configs import load_configs
 from nessie.jobs.queue import initialize_job_queue
-from nessie.jobs.scheduling import initialize_job_schedules
+from nessie.jobs.scheduling import initialize_job_schedules, run_startup_jobs
 from nessie.logger import initialize_logger
 from nessie.routes import register_routes
 
@@ -49,5 +49,6 @@ def create_app():
         if not app.debug or os.environ.get('WERKZEUG_RUN_MAIN') == 'true':
             initialize_job_schedules(app)
             initialize_job_queue(app)
+            run_startup_jobs(app)
 
     return app

--- a/nessie/jobs/create_metadata_schema.py
+++ b/nessie/jobs/create_metadata_schema.py
@@ -32,15 +32,15 @@ from nessie.externals import redshift
 from nessie.jobs.background_job import BackgroundJob, resolve_sql_template
 
 
-class CreateAscSchema(BackgroundJob):
+class CreateMetadataSchema(BackgroundJob):
 
     def run(self):
-        app.logger.info(f'Starting ASC schema creation job...')
+        app.logger.info(f'Starting metadata schema creation job...')
         app.logger.info(f'Executing SQL...')
-        resolved_ddl = resolve_sql_template('create_asc_schema.template.sql')
+        resolved_ddl = resolve_sql_template('create_metadata_schema.template.sql')
         if redshift.execute_ddl_script(resolved_ddl):
-            app.logger.info(f"Schema '{app.config['REDSHIFT_SCHEMA_ASC']}' found or created.")
+            app.logger.info(f"Schema '{app.config['REDSHIFT_SCHEMA_METADATA']}' found or created.")
         else:
-            app.logger.error(f'ASC schema creation failed.')
+            app.logger.error(f'Metadata schema creation failed.')
             return False
         return True

--- a/nessie/jobs/generate_asc_profiles.py
+++ b/nessie/jobs/generate_asc_profiles.py
@@ -1,0 +1,102 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from functools import reduce
+from itertools import groupby
+import json
+import operator
+
+from flask import current_app as app
+from nessie.externals import redshift, s3
+from nessie.jobs.background_job import BackgroundJob, get_s3_asc_daily_path, resolve_sql_template_string
+import psycopg2
+
+
+"""Logic for ASC profile generation job."""
+
+
+asc_schema = app.config['REDSHIFT_SCHEMA_ASC']
+asc_schema_identifier = psycopg2.sql.Identifier(asc_schema)
+
+
+class GenerateAscProfiles(BackgroundJob):
+
+    def run(self):
+        app.logger.info(f'Starting ASC profile generation job...')
+        asc_rows = redshift.fetch(
+            'SELECT * FROM {schema}.students ORDER by sid, UPPER(team_name)',
+            schema=asc_schema_identifier,
+        )
+
+        profile_rows = []
+
+        for sid, rows_for_student in groupby(asc_rows, operator.itemgetter('sid')):
+            rows_for_student = list(rows_for_student)
+            # Since BOAC believes (falsely) that isActiveAsc and statusAsc are attributes of a student, not
+            # a team membership, a bit of brutal simplification is needed. Students who are active in at least
+            # one sport have inactive team memberships dropped.
+            any_active_athletics = reduce(operator.or_, [r['active'] for r in rows_for_student], False)
+            if any_active_athletics:
+                rows_for_student = [r for r in rows_for_student if r['active']]
+            athletics_profile = {
+                'athletics': [],
+                'inIntensiveCohort': rows_for_student[0]['intensive'],
+                'isActiveAsc': rows_for_student[0]['active'],
+                'statusAsc': rows_for_student[0]['status_asc'],
+            }
+            for row in rows_for_student:
+                athletics_profile['athletics'].append({
+                    'groupCode': row['group_code'],
+                    'groupName': row['group_name'],
+                    'name': row['group_name'],
+                    'teamCode': row['team_code'],
+                    'teamName': row['team_name'],
+                })
+
+            profile_rows.append('\t'.join([str(sid), json.dumps(athletics_profile)]))
+
+        s3_key = f'{get_s3_asc_daily_path()}/athletics_profiles.tsv'
+        app.logger.info(f'Will stash {len(profile_rows)} feeds in S3: {s3_key}')
+        if not s3.upload_data('\n'.join(profile_rows), s3_key):
+            app.logger.error('Error on S3 upload: aborting job.')
+            return False
+
+        app.logger.info('Will copy S3 feeds into Redshift...')
+        query = resolve_sql_template_string(
+            """
+            TRUNCATE {redshift_schema_asc}.student_profiles;
+            COPY {redshift_schema_asc}.student_profiles
+                FROM '{loch_s3_asc_data_path}/athletics_profiles.tsv'
+                IAM_ROLE '{redshift_iam_role}'
+                DELIMITER '\\t';
+            VACUUM;
+            ANALYZE;
+            """,
+        )
+        if not redshift.execute(query):
+            app.logger.error('Error on Redshift copy: aborting job.')
+            return False
+
+        return 'ASC profile generation complete.'

--- a/nessie/sql_templates/create_asc_schema.template.sql
+++ b/nessie/sql_templates/create_asc_schema.template.sql
@@ -28,14 +28,13 @@
 -- Internal Schema
 --------------------------------------------------------------------
 
-DROP SCHEMA IF EXISTS {redshift_schema_asc} CASCADE;
-CREATE SCHEMA {redshift_schema_asc};
+CREATE SCHEMA IF NOT EXISTS {redshift_schema_asc};
 
 --------------------------------------------------------------------
 -- Internal Tables
 --------------------------------------------------------------------
 
-CREATE TABLE {redshift_schema_asc}.students
+CREATE TABLE IF NOT EXISTS {redshift_schema_asc}.students
 (
     sid VARCHAR NOT NULL,
     active BOOLEAN NOT NULL,
@@ -49,7 +48,7 @@ CREATE TABLE {redshift_schema_asc}.students
 DISTKEY (group_code)
 INTERLEAVED SORTKEY (sid, intensive, active, group_code);
 
-CREATE TABLE {redshift_schema_asc}.student_profiles
+CREATE TABLE IF NOT EXISTS {redshift_schema_asc}.student_profiles
 (
     sid VARCHAR NOT NULL,
     profile VARCHAR(max) NOT NULL

--- a/nessie/sql_templates/create_metadata_schema.template.sql
+++ b/nessie/sql_templates/create_metadata_schema.template.sql
@@ -28,16 +28,16 @@ CREATE SCHEMA IF NOT EXISTS {redshift_schema_metadata};
 CREATE TABLE IF NOT EXISTS {redshift_schema_metadata}.background_job_status
 (
     job_id VARCHAR NOT NULL,
-    # Possible 'status' values: 'started', 'succeeded', 'failed'
+    -- Possible 'status' values: 'started', 'succeeded', 'failed'
     status VARCHAR NOT NULL,
     instance_id VARCHAR,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL,
     details VARCHAR(4096),
-    # Primary key constraints are not enforced by Redshift but are used in query planning.
-    # https://docs.aws.amazon.com/redshift/latest/dg/t_Defining_constraints.html
+    -- Primary key constraints are not enforced by Redshift but are used in query planning.
+    -- https://docs.aws.amazon.com/redshift/latest/dg/t_Defining_constraints.html
     PRIMARY KEY (job_id)
-)
+);
 
 CREATE TABLE IF NOT EXISTS {redshift_schema_metadata}.canvas_sync_job_status
 (
@@ -48,16 +48,16 @@ CREATE TABLE IF NOT EXISTS {redshift_schema_metadata}.canvas_sync_job_status
     source_size BIGINT,
     destination_url VARCHAR(1024),
     destination_size BIGINT,
-    # Possible 'status' values:
-    # - 'created': the master node has identified a source file in Canvas and will dispatch a sync job
-    # - 'received': the worker node has received the dispatch request
-    # - 'started': the worker node has started a background thread for the sync job
-    # - 'streaming': the worker node has started streaming the file to S3
-    # - 'complete': the worker node has completed the file upload to S3
-    # - 'duplicate': the worker node has found a duplicate file in S3 and will not upload
-    # - 'error': an error occurred.
+    -- Possible 'status' values:
+    -- - 'created': the master node has identified a source file in Canvas and will dispatch a sync job
+    -- - 'received': the worker node has received the dispatch request
+    -- - 'started': the worker node has started a background thread for the sync job
+    -- - 'streaming': the worker node has started streaming the file to S3
+    -- - 'complete': the worker node has completed the file upload to S3
+    -- - 'duplicate': the worker node has found a duplicate file in S3 and will not upload
+    -- - 'error': an error occurred.
     status VARCHAR NOT NULL,
-    # Further details on job status. Currently used only for errors.
+    -- Further details on job status. Currently used only for errors.
     details VARCHAR(4096),
     instance_id VARCHAR,
     created_at TIMESTAMP NOT NULL,

--- a/nessie/sql_templates/create_student_schema.template.sql
+++ b/nessie/sql_templates/create_student_schema.template.sql
@@ -23,10 +23,9 @@
  * ENHANCEMENTS, OR MODIFICATIONS.
  */
 
-DROP SCHEMA IF EXISTS {redshift_schema_student} CASCADE;
-CREATE SCHEMA {redshift_schema_student};
+CREATE SCHEMA IF NOT EXISTS {redshift_schema_student};
 
-CREATE TABLE {redshift_schema_student}.sis_api_degree_progress
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.sis_api_degree_progress
 (
     sid VARCHAR NOT NULL,
     feed VARCHAR(max) NOT NULL
@@ -34,7 +33,7 @@ CREATE TABLE {redshift_schema_student}.sis_api_degree_progress
 DISTKEY(sid)
 SORTKEY(sid);
 
-CREATE TABLE {redshift_schema_student}.sis_api_drops_and_midterms
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.sis_api_drops_and_midterms
 (
     sid VARCHAR NOT NULL,
     term_id VARCHAR(4) NOT NULL,
@@ -43,7 +42,7 @@ CREATE TABLE {redshift_schema_student}.sis_api_drops_and_midterms
 DISTKEY(sid)
 SORTKEY(sid, term_id);
 
-CREATE TABLE {redshift_schema_student}.sis_api_profiles
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.sis_api_profiles
 (
     sid VARCHAR NOT NULL,
     feed VARCHAR(max) NOT NULL
@@ -51,7 +50,7 @@ CREATE TABLE {redshift_schema_student}.sis_api_profiles
 DISTKEY(sid)
 SORTKEY(sid);
 
-CREATE TABLE {redshift_schema_student}.student_profiles
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.student_profiles
 (
     sid VARCHAR NOT NULL,
     profile VARCHAR(max) NOT NULL
@@ -59,7 +58,7 @@ CREATE TABLE {redshift_schema_student}.student_profiles
 DISTKEY (sid)
 SORTKEY (sid);
 
-CREATE TABLE {redshift_schema_student}.student_academic_status
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.student_academic_status
 (
     sid VARCHAR NOT NULL,
     uid VARCHAR NOT NULL,
@@ -72,7 +71,7 @@ CREATE TABLE {redshift_schema_student}.student_academic_status
 DISTKEY (units)
 INTERLEAVED SORTKEY (sid, last_name, level, gpa, units, uid, first_name);
 
-CREATE TABLE {redshift_schema_student}.student_majors
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.student_majors
 (
     sid VARCHAR NOT NULL,
     major VARCHAR NOT NULL
@@ -80,7 +79,7 @@ CREATE TABLE {redshift_schema_student}.student_majors
 DISTKEY (major)
 SORTKEY (major);
 
-CREATE TABLE {redshift_schema_student}.student_enrollment_terms
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.student_enrollment_terms
 (
     sid VARCHAR NOT NULL,
     term_id VARCHAR(4) NOT NULL,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-168

In addition to startup check,
- Get the components of API-triggered chained jobs in alignment with scheduled jobs;
- Rename the old CreateAscSchema job (which no longer creates the ASC schema) to GenerateAscProfiles (which is what it does).

Because of the job rename, this might be a good candidate for a pre-deploy QA PR, so that we don't get a confusingly named job stuck in the SQLAlchemy store.