### PR TITLE
NS-178, minor upgrades: SQLAlchemy, pandas, pytest, etc.

### DIFF
--- a/.ebextensions/41_install_pandas.config
+++ b/.ebextensions/41_install_pandas.config
@@ -3,4 +3,4 @@
 #
 container_commands:
   01_install_pandas:
-    command: '/opt/python/run/venv/bin/pip install pandas==0.21.1'
+    command: '/opt/python/run/venv/bin/pip install pandas==0.23.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 install:
   - pip install google-compute-engine # see https://github.com/tendenci/tendenci/issues/539
   - pip3 install -r requirements.txt
-  - pip3 install pandas==0.21.1
+  - pip3 install pandas==0.23.3
   - pip3 install tox
 
 script:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Networked engines supply statistics in education.
 
 ```
 pip3 install -r requirements.txt [--upgrade]
-pip3 install pandas==0.21.1
+pip3 install pandas==0.23.3
 ```
 
 ### Create Postgres user and databases

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,29 @@
 Flask==0.12.2
 Flask-SQLAlchemy==2.3.2
-SQLAlchemy==1.2.8
+SQLAlchemy==1.2.10
 Werkzeug==0.14
 apscheduler==3.5.1
-boto3==1.7.40
+boto3==1.7.65
 decorator==4.3.0
 ldap3==2.5
-psycopg2==2.7.4
-pytz==2017.3
+psycopg2==2.7.5
+pytz==2018.5
 requests==2.19.1
-simplejson==3.15.0
+simplejson==3.16.0
 xmltodict==0.11.0
 # ETS fork of https://github.com/RaRe-Technologies/smart_open, with added support for S3 upload arguments.
 https://github.com/ets-berkeley-edu/smart_open/archive/master.zip
 
-# Dependencies for pandas 0.21.1. Note that pandas is not included in this requirements.txt file because
+# Dependencies for pandas 0.23.3. Note that pandas is not included in this requirements.txt file because
 # of potential conflicts during installation; it must be separately installed once its dependencies are
 # in place.
-numpy==1.14.5
+numpy==1.15.0
 python-dateutil==2.7.3
 
 # For testing
 
 https://github.com/gabrielfalcao/HTTPretty/archive/master.zip
 moto==1.3.3
-pytest==3.6.1
+pytest==3.6.3
 pytest-flask==0.10.0
-tox==3.0.0
+tox==3.1.2


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-178

`pandas` upgrade seems like a good idea. Read v0.23.2 notes: https://github.com/pandas-dev/pandas/releases