### PR TITLE
NS-164 Let Nessie "master" & "worker" deployments share a config file

### DIFF
--- a/.ebextensions/20_download_local_configuration.config
+++ b/.ebextensions/20_download_local_configuration.config
@@ -5,7 +5,8 @@
 container_commands:
   01_get_configuration_file:
     command: |
-      PYTHONPATH='' aws s3 cp s3://la-deploy-configs/nessie/${EB_ENVIRONMENT}.py config/production-local.py
+      CONFIG_NAME=$(echo "${EB_ENVIRONMENT}" | sed -E -e 's/(-worker|-master)//')
+      PYTHONPATH='' aws s3 cp s3://la-deploy-configs/nessie/${CONFIG_NAME}.py config/production-local.py
       printf "\nEB_ENVIRONMENT = '${EB_ENVIRONMENT}'\n\n" >> config/production-local.py
       chown wsgi config/production-local.py
       chmod 400 config/production-local.py

--- a/config/default.py
+++ b/config/default.py
@@ -80,7 +80,9 @@ ENROLLMENTS_API_KEY = 'secretkey'
 ENROLLMENTS_API_URL = 'https://secreturl.berkeley.edu/enrollments'
 
 # True on master node, false on worker nodes.
+# Override by embedding "master" or "worker" in the EB_ENVIRONMENT environment variable.
 JOB_SCHEDULING_ENABLED = True
+
 # See http://apscheduler.readthedocs.io/en/latest/modules/triggers/cron.html for supported schedule formats.
 JOB_SYNC_CANVAS_SNAPSHOTS = {'hour': 1, 'minute': 0}
 JOB_RESYNC_CANVAS_SNAPSHOTS = {'hour': 1, 'minute': 40}

--- a/scripts/deploy_nessie_config.sh
+++ b/scripts/deploy_nessie_config.sh
@@ -35,7 +35,8 @@ else
 fi
 
 # Download from Amazon S3
-config_location="s3://la-deploy-configs/nessie/${eb_env}.py"
+config_name=$(echo "${eb_env}" | sed -E -e 's/(-worker|-master)//')
+config_location="s3://la-deploy-configs/nessie/${config_name}.py"
 
 echo "In five seconds, ${config_location} will be copied to ${local_config}."; echo
 echo "Use CTRL-C to abort..."; echo

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,44 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+import os
+
+from nessie import factory
+from tests.util import override_config
+
+
+class TestFactory:
+
+    def test_enable_scheduling_through_config(self, app):
+        with override_config(app, 'JOB_SCHEDULING_ENABLED', True):
+            factory.configure_scheduler_mode(app)
+            assert app.config['JOB_SCHEDULING_ENABLED'] is True
+
+    def test_disable_scheduling_through_env(self, app):
+        with override_config(app, 'JOB_SCHEDULING_ENABLED', True):
+            os.environ['EB_ENVIRONMENT'] = 'nessie-worker-bee'
+            factory.configure_scheduler_mode(app)
+            assert app.config['JOB_SCHEDULING_ENABLED'] is False


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-164

Given the choice between "Rails-y magic string conventions" and "Pythonic explicit configurations", I picked the option which requires less AWS EBS maintenance. Our new shared config filenames would therefore be EB_ENVIRONMENT minus any "-worker" or "-master" substring.