### PR TITLE
NS-224 Brain transplant for Mockingbird: httpretty -> responses

### DIFF
--- a/config/testext.py
+++ b/config/testext.py
@@ -11,10 +11,14 @@ REDSHIFT_USER = 'username'
 
 REDSHIFT_SCHEMA_ASC = 'testext_mynamehere_asc'
 REDSHIFT_SCHEMA_BOAC = 'testext_mynamehere_boac'
+REDSHIFT_SCHEMA_CALNET = 'testext_mynamehere_calnet'
 REDSHIFT_SCHEMA_CANVAS = 'testext_mynamehere_canvas'
+REDSHIFT_SCHEMA_COE = 'testext_mynamehere_coe'
+REDSHIFT_SCHEMA_COE_EXTERNAL = 'testext_mynamehere_coe_external'
 REDSHIFT_SCHEMA_INTERMEDIATE = 'testext_mynamehere_intermediate'
 REDSHIFT_SCHEMA_METADATA = 'testext_mynamehere_metadata'
 REDSHIFT_SCHEMA_SIS = 'testext_mynamehere_sis'
+REDSHIFT_SCHEMA_SIS_INTERNAL = 'testext_mynamehere_sis_internal'
 REDSHIFT_SCHEMA_STUDENT = 'testext_mynamehere_student'
 
 # S3 key prefix. Since the testext bucket is shared between users, choose something unique.

--- a/nessie/lib/mockingbird.py
+++ b/nessie/lib/mockingbird.py
@@ -32,11 +32,11 @@ import re
 import urllib
 
 from flask import current_app as app
-import httpretty
 from nessie.lib.util import fill_pattern_from_args
+import responses
 
 
-"""This module wraps the httpretty package to return fake external API responses in test or demo mode.
+"""This module wraps the responses package to return fake external API responses in test or demo mode.
 
 A module can define mock behavior by using the @mockable decorator on a function that calls an external URL, and the
 @mocking decorator on a function that returns the fake response.
@@ -46,9 +46,9 @@ A test function can temporarily substitute custom mock behavior with the registe
 
 
 class MockResponse:
-    """A callable object that can be passed into httpretty's register_uri method with the 'body' keyword.
+    """A callable object that can be passed into responses' add_callback method with the 'callback' keyword.
 
-    Despite that keyword's name, it takes a tuple including status and headers as well as response body.
+    That keyword expects a function returning a three-part tuple: status, headers, and body.
 
     Functions that use the @mocking decorator should return a MockResponse object.
 
@@ -81,8 +81,8 @@ def _unregister_mock(request_function):
 def mockable(func):
     """Mark function as mockable.
 
-    Since httpretty registers mock responses against URLs, the function to be decorated must generate (or have access
-    to) the complete URL to be called.
+    Since the responses package registers mock responses against URLs, the function to be decorated must generate
+    (or have access to) the complete URL to be called.
 
     Functions using this decorator should accept an optional 'mock' argument. The decorator will replace this argument
     with a context manager that activates the mock response currently associated to the mockable function in the
@@ -282,11 +282,10 @@ def register_mock(request_function, response):
 @contextmanager
 def _activate_mock(url, mock_response, method='get'):
     if mock_response and _environment_supports_mocks():
-        httpretty.enable()
-        http_method = getattr(httpretty, method.upper())
-        httpretty.register_uri(http_method, url, body=mock_response)
-        yield
-        httpretty.disable()
+        with responses.RequestsMock() as rsps:
+            http_method = getattr(responses, method.upper())
+            rsps.add_callback(http_method, url, callback=mock_response)
+            yield
     else:
         yield
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,8 @@ python-dateutil==2.7.3
 
 # For testing
 
-https://github.com/gabrielfalcao/HTTPretty/archive/master.zip
 moto==1.3.3
 pytest==3.8.0
 pytest-flask==0.12.0
+responses==0.9.0
 tox==3.3.0

--- a/tests/test_externals/test_s3.py
+++ b/tests/test_externals/test_s3.py
@@ -24,9 +24,9 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from botocore.exceptions import ConnectionError
-import httpretty
 from nessie.externals import s3
 import pytest
+import responses
 from tests.util import capture_app_logs, mock_s3
 
 
@@ -63,13 +63,13 @@ class TestS3:
 class TestS3Testext:
     """S3 client with live external connections."""
 
-    @httpretty.activate
+    @responses.activate
     def test_source_url_error_handling(self, app, caplog):
         """Handles and logs connection errors to source URL."""
         with capture_app_logs(app):
             url = 'http://shakespeare.mit.edu/Poetry/sonnet.XLV.html'
             key = app.config['LOCH_S3_PREFIX_TESTEXT'] + '/00001/sonnet-xlv.html'
-            httpretty.register_uri(httpretty.GET, url, status=500, body='{"message": "Internal server error."}')
+            responses.add(responses.GET, url, status=500, body='{"message": "Internal server error."}')
             with pytest.raises(ConnectionError):
                 s3.upload_from_url(url, key)
                 assert 'Received unexpected status code, aborting S3 upload' in caplog.text

--- a/tests/test_externals/test_sis_enrollments_api.py
+++ b/tests/test_externals/test_sis_enrollments_api.py
@@ -127,10 +127,9 @@ class TestSisEnrollmentsApi:
         assert enrollments[5]['grades'][0]['mark'] == 'P'
 
     def test_user_not_found(self, app, caplog):
-        """Logs 404 for unknown user and returns informative message."""
+        """Notes 404 for unknown user and returns informative message, but does not add noise to the log."""
         caplog.set_level(logging.DEBUG)
         response = enrollments_api._get_enrollments(9999999, 2178)
-        assert 'HTTP/1.1" 404' in caplog.text
         assert not response
         assert response.raw_response.status_code == 404
         assert response.raw_response.json()['message']

--- a/tests/test_jobs/test_sync_file_to_s3.py
+++ b/tests/test_jobs/test_sync_file_to_s3.py
@@ -23,6 +23,8 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+import logging
+
 from nessie.externals import redshift
 from nessie.jobs.sync_file_to_s3 import SyncFileToS3
 from nessie.lib import metadata
@@ -40,6 +42,7 @@ class TestSyncFileToS3:
         url = 'http://shakespeare.mit.edu/Poetry/sonnet.XLV.html'
         key = app.config['LOCH_S3_PREFIX_TESTEXT'] + '/00001/sonnet-xlv.html'
 
+        caplog.set_level(logging.DEBUG)
         with capture_app_logs(app):
             result = SyncFileToS3().run(url=url, key=key)
             assert result is True

--- a/tests/util.py
+++ b/tests/util.py
@@ -31,7 +31,6 @@ import logging
 import boto3
 import moto
 from nessie.externals import redshift
-import responses
 
 
 @contextmanager
@@ -49,9 +48,6 @@ def capture_app_logs(app):
 
 @contextmanager
 def mock_s3(app):
-    # Allow calls to live external URLs during tests; currently our tests are using shakespeare.mit.edu.
-    # TODO See if we can get httpretty and/or responses to sit nicely beside moto in non-testext mode.
-    responses.add_passthru('http://')
     with moto.mock_s3():
         s3 = boto3.resource('s3', app.config['LOCH_S3_REGION'])
         s3.create_bucket(Bucket=app.config['LOCH_S3_BUCKET'])


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-224

(For background on the responses package, see https://cra.mr/2014/05/20/mocking-requests-with-responses - it's designed after httpretty but simpler, which fits our usage and seems to cause fewer conflicts.)