### PR TITLE
BOAC-1259 Include per-course means, excluding zeros, in analytics feeds

### DIFF
--- a/nessie/lib/analytics.py
+++ b/nessie/lib/analytics.py
@@ -31,6 +31,7 @@ from statistics import mean
 
 from flask import current_app as app
 from nessie.lib import queries
+from numpy import nan
 import pandas
 
 
@@ -139,6 +140,7 @@ def analytics_for_column(df, student_row, column_name):
                 'roundedUpPercentile': None,
             },
             'courseDeciles': None,
+            'courseMean': None,
             'displayPercentile': None,
         }
 
@@ -158,6 +160,10 @@ def analytics_for_column(df, student_row, column_name):
     # Note, however, that if all students have the same score, then all students are in the "100th percentile."
     display_percentile = ordinal(intuitive_percentile)
 
+    # Ignore zeros for purposes of calculating the course-level mean. As described above, these might indicate real zeros
+    # or missing data, and including them in our current metrics (especially lastActivity) skews the result.
+    course_mean = dfcol.replace(0, nan).dropna().mean()
+
     app.logger.debug(f'Returning calculated analytics (column_name={column_name})')
     return {
         'boxPlottable': box_plottable,
@@ -167,6 +173,7 @@ def analytics_for_column(df, student_row, column_name):
             'roundedUpPercentile': intuitive_percentile,
         },
         'courseDeciles': column_quantiles,
+        'courseMean': course_mean,
         'displayPercentile': display_percentile,
     }
 

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -61,6 +61,7 @@ class TestAnalyticsFromAssignmentsSubmitted:
         assert digested['courseDeciles'][0] == 0
         assert digested['courseDeciles'][9] == 10
         assert digested['courseDeciles'][10] == 17
+        assert round(digested['courseMean']) == 7
 
     def test_small_difference(self, app):
         """Notices that small difference."""
@@ -112,6 +113,7 @@ class TestAnalyticsFromAssignmentsSubmitted:
         assert digested['student']['percentile'] is None
         assert digested['boxPlottable'] is False
         assert digested['courseDeciles'] is None
+        assert digested['courseMean'] is None
 
 
 class TestStudentAnalytics:
@@ -135,6 +137,7 @@ class TestStudentAnalytics:
         assert score['courseDeciles'][0] == 47
         assert score['courseDeciles'][9] == 94
         assert score['courseDeciles'][10] == 104
+        assert round(score['courseMean']) == 77
         last_activity = digested['lastActivity']
         assert last_activity['student']['raw'] == 1535275620
         assert last_activity['student']['percentile'] == 93
@@ -142,6 +145,7 @@ class TestStudentAnalytics:
         assert last_activity['courseDeciles'][0] == 1533021840
         assert last_activity['courseDeciles'][9] == 1535264940
         assert last_activity['courseDeciles'][10] == 1535533860
+        assert round(last_activity['courseMean']) == 1534450943
 
     def test_with_empty_redshift(self, app):
         bad_course_id = 'NoSuchSite'
@@ -160,5 +164,6 @@ class TestStudentAnalytics:
         assert score['student']['percentile'] is None
         assert score['boxPlottable'] is False
         assert score['courseDeciles'] is None
+        assert score['courseMean'] is None
         last_activity = digested['lastActivity']
         assert last_activity['student']['raw'] is 0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1259