### PR TITLE
BOAC-1259 Include comparative percentiles for course means

### DIFF
--- a/nessie/lib/analytics.py
+++ b/nessie/lib/analytics.py
@@ -163,6 +163,10 @@ def analytics_for_column(df, student_row, column_name):
     # Ignore zeros for purposes of calculating the course-level mean. As described above, these might indicate real zeros
     # or missing data, and including them in our current metrics (especially lastActivity) skews the result.
     course_mean = dfcol.replace(0, nan).dropna().mean()
+    if course_mean and not math.isnan(course_mean):
+        comparative_percentile_of_mean = zptile(zscore(dfcol, course_mean))
+    else:
+        comparative_percentile_of_mean = None
 
     app.logger.debug(f'Returning calculated analytics (column_name={column_name})')
     return {
@@ -173,7 +177,10 @@ def analytics_for_column(df, student_row, column_name):
             'roundedUpPercentile': intuitive_percentile,
         },
         'courseDeciles': column_quantiles,
-        'courseMean': course_mean,
+        'courseMean': {
+            'percentile': comparative_percentile_of_mean,
+            'raw': course_mean,
+        },
         'displayPercentile': display_percentile,
     }
 

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -61,7 +61,8 @@ class TestAnalyticsFromAssignmentsSubmitted:
         assert digested['courseDeciles'][0] == 0
         assert digested['courseDeciles'][9] == 10
         assert digested['courseDeciles'][10] == 17
-        assert round(digested['courseMean']) == 7
+        assert round(digested['courseMean']['raw']) == 7
+        assert digested['courseMean']['percentile'] == 51
 
     def test_small_difference(self, app):
         """Notices that small difference."""
@@ -137,7 +138,8 @@ class TestStudentAnalytics:
         assert score['courseDeciles'][0] == 47
         assert score['courseDeciles'][9] == 94
         assert score['courseDeciles'][10] == 104
-        assert round(score['courseMean']) == 77
+        assert round(score['courseMean']['raw']) == 77
+        assert score['courseMean']['percentile'] == 50
         last_activity = digested['lastActivity']
         assert last_activity['student']['raw'] == 1535275620
         assert last_activity['student']['percentile'] == 93
@@ -145,7 +147,8 @@ class TestStudentAnalytics:
         assert last_activity['courseDeciles'][0] == 1533021840
         assert last_activity['courseDeciles'][9] == 1535264940
         assert last_activity['courseDeciles'][10] == 1535533860
-        assert round(last_activity['courseMean']) == 1534450943
+        assert round(last_activity['courseMean']['raw']) == 1534450943
+        assert last_activity['courseMean']['percentile'] == 50
 
     def test_with_empty_redshift(self, app):
         bad_course_id = 'NoSuchSite'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1259

Follow-up to #209. For matrix plotting we need comparative percentiles, not just raw values.