### PR TITLE
 NS-226 Move current-date calls out of function signatures; test coverage

### DIFF
--- a/nessie/lib/util.py
+++ b/nessie/lib/util.py
@@ -61,14 +61,14 @@ def vacuum_whitespace(_str):
     return ' '.join(_str.split())
 
 
-def get_s3_asc_daily_path(cutoff=datetime.now()):
-    today = localize_datetime(cutoff).strftime('%Y-%m-%d')
+def get_s3_asc_daily_path(cutoff=None):
+    today = localize_datetime(cutoff or datetime.now()).strftime('%Y-%m-%d')
     today_hash = hashlib.md5(today.encode('utf-8')).hexdigest()
     return app.config['LOCH_S3_ASC_DATA_PATH'] + '/daily/' + today_hash + '-' + today
 
 
-def get_s3_calnet_daily_path(cutoff=datetime.now()):
-    today = localize_datetime(cutoff).strftime('%Y-%m-%d')
+def get_s3_calnet_daily_path(cutoff=None):
+    today = localize_datetime(cutoff or datetime.now()).strftime('%Y-%m-%d')
     today_hash = hashlib.md5(today.encode('utf-8')).hexdigest()
     return app.config['LOCH_S3_CALNET_DATA_PATH'] + '/daily/' + today_hash + '-' + today
 
@@ -81,7 +81,7 @@ def get_s3_canvas_daily_path():
     return app.config['LOCH_S3_CANVAS_DATA_PATH_DAILY'] + '/' + today_hash + '-' + today
 
 
-def get_s3_coe_daily_path(cutoff=datetime.now()):
+def get_s3_coe_daily_path(cutoff=None):
     # TODO: When COE is delivering data daily then unleash the following logic
     # today = localize_datetime(cutoff).strftime('%Y-%m-%d')
     # today_hash = hashlib.md5(today.encode('utf-8')).hexdigest()
@@ -89,15 +89,15 @@ def get_s3_coe_daily_path(cutoff=datetime.now()):
     return app.config['LOCH_S3_COE_DATA_PATH']
 
 
-def get_s3_sis_daily_path(cutoff=datetime.now()):
-    today = localize_datetime(cutoff).strftime('%Y-%m-%d')
+def get_s3_sis_daily_path(cutoff=None):
+    today = localize_datetime(cutoff or datetime.now()).strftime('%Y-%m-%d')
     today_hash = hashlib.md5(today.encode('utf-8')).hexdigest()
     return app.config['LOCH_S3_SIS_DATA_PATH'] + '/daily/' + today_hash + '-' + today
 
 
-def get_s3_sis_api_daily_path(cutoff=datetime.now()):
+def get_s3_sis_api_daily_path(cutoff=None):
     # Path for stashed SIS API data that doesn't need to be queried by Redshift Spectrum.
-    today = localize_datetime(cutoff).strftime('%Y-%m-%d')
+    today = localize_datetime(cutoff or datetime.now()).strftime('%Y-%m-%d')
     today_hash = hashlib.md5(today.encode('utf-8')).hexdigest()
     return app.config['LOCH_S3_SIS_API_DATA_PATH'] + '/daily/' + today_hash + '-' + today
 

--- a/tests/test_jobs/test_import_degree_progress.py
+++ b/tests/test_jobs/test_import_degree_progress.py
@@ -1,0 +1,43 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import json
+
+from nessie.externals import redshift
+from tests.util import mock_s3
+
+
+class TestImportDegreeProgress:
+
+    def test_import_degree_progress(self, app, metadata_db, student_tables, caplog):
+        from nessie.jobs.import_degree_progress import ImportDegreeProgress
+        with mock_s3(app):
+            result = ImportDegreeProgress().run_wrapped()
+        assert result == 'SIS degree progress API import job completed: 1 succeeded, 7 returned no information, 0 failed.'
+        rows = redshift.fetch('SELECT * FROM student_test.sis_api_degree_progress')
+        assert len(rows) == 1
+        assert rows[0]['sid'] == '11667051'
+        feed = json.loads(rows[0]['feed'])
+        assert feed['requirements']['entryLevelWriting']['status'] == 'Satisfied'

--- a/tests/test_jobs/test_import_sis_enrollments_api.py
+++ b/tests/test_jobs/test_import_sis_enrollments_api.py
@@ -1,0 +1,46 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import json
+
+from nessie.externals import redshift
+from tests.util import mock_s3
+
+
+class TestImportSisEnrollmentsApi:
+
+    def test_import_sis_enrollments_api(self, app, metadata_db, student_tables, caplog):
+        from nessie.jobs.import_sis_enrollments_api import ImportSisEnrollmentsApi
+        with mock_s3(app):
+            result = ImportSisEnrollmentsApi().run_wrapped()
+        assert result == 'SIS enrollments API import completed for term 2178: 1 succeeded, 7 returned no enrollments, 0 failed.'
+        rows = redshift.fetch('SELECT * FROM student_test.sis_api_drops_and_midterms')
+        assert len(rows) == 1
+        assert rows[0]['sid'] == '11667051'
+        feed = json.loads(rows[0]['feed'])
+        assert feed['droppedPrimarySections'][0]['displayName'] == 'MUSIC 41C'
+        assert feed['droppedPrimarySections'][0]['component'] == 'TUT'
+        assert feed['droppedPrimarySections'][0]['sectionNumber'] == '002'
+        assert feed['midtermGrades']['90100'] == 'D+'

--- a/tests/test_jobs/test_import_sis_student_api.py
+++ b/tests/test_jobs/test_import_sis_student_api.py
@@ -1,0 +1,45 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import json
+
+from nessie.externals import redshift
+from tests.util import mock_s3
+
+
+class TestImportSisStudentApi:
+
+    def test_import_sis_student_api(self, app, metadata_db, student_tables, caplog):
+        from nessie.jobs.import_sis_student_api import ImportSisStudentApi
+        with mock_s3(app):
+            result = ImportSisStudentApi().run_wrapped()
+        assert result == 'SIS student API import job completed: 2 succeeded, 6 failed.'
+        rows = redshift.fetch('SELECT * FROM student_test.sis_api_profiles ORDER BY sid')
+        print(rows)
+        assert len(rows) == 2
+        assert rows[0]['sid'] == '11667051'
+        assert rows[1]['sid'] == '2345678901'
+        feed = json.loads(rows[0]['feed'], strict=False)
+        assert feed['names'][0]['familyName'] == 'Bear'


### PR DESCRIPTION
The briefer commit is the one that addresses https://jira.ets.berkeley.edu/jira/browse/NS-226. Added test coverage is just an olive on top.