### PR TITLE
NS-240 Support max varchar length on LRS statements in Redshift

### DIFF
--- a/nessie/sql_templates/create_lrs_schema.template.sql
+++ b/nessie/sql_templates/create_lrs_schema.template.sql
@@ -40,7 +40,7 @@ CREATE EXTERNAL DATABASE IF NOT EXISTS;
 
 CREATE EXTERNAL TABLE {redshift_schema_lrs_external}.statements(
     uuid VARCHAR,
-    statement VARCHAR,
+    statement VARCHAR(max),
     verb VARCHAR,
     "timestamp" TIMESTAMP,
     activity_type VARCHAR,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-240

Per review from @sandeepmjay on #220.

`varchar(max)` is used elsewhere in Nessie and presently works out to 65535.
https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html#r_Character_types-storage-and-ranges