### PR TITLE
NS-235 WORKER_QUEUE_ENABLED should only affect Worker instances

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -165,6 +165,6 @@ TERMS_API_URL = 'https://secreturl.berkeley.edu/terms'
 
 WORKER_HOST = 'hard-working-nessie.berkeley.edu'
 
-# True on worker nodes, false on master node.
-WORKER_QUEUE_ENABLED = False
+# Thread queues will be ignored if "master" is embedded in the EB_ENVIRONMENT environment variable.
+WORKER_QUEUE_ENABLED = True
 WORKER_THREADS = 5

--- a/nessie/factory.py
+++ b/nessie/factory.py
@@ -64,6 +64,9 @@ def configure_scheduler_mode(app):
             override_mode = False
         elif 'master' in eb_environment:
             override_mode = True
+            if app.config['WORKER_QUEUE_ENABLED']:
+                app.logger.info('Changing WORKER_QUEUE_ENABLED to False')
+                app.config['WORKER_QUEUE_ENABLED'] = False
         else:
             override_mode = None
         if override_mode is not None and override_mode is not default_scheduler_mode:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -36,9 +36,18 @@ class TestFactory:
         with override_config(app, 'JOB_SCHEDULING_ENABLED', True):
             factory.configure_scheduler_mode(app)
             assert app.config['JOB_SCHEDULING_ENABLED'] is True
+            assert app.config['WORKER_QUEUE_ENABLED'] is True
 
     def test_disable_scheduling_through_env(self, app):
         with override_config(app, 'JOB_SCHEDULING_ENABLED', True):
             os.environ['EB_ENVIRONMENT'] = 'nessie-worker-bee'
             factory.configure_scheduler_mode(app)
             assert app.config['JOB_SCHEDULING_ENABLED'] is False
+            assert app.config['WORKER_QUEUE_ENABLED'] is True
+
+    def test_no_thread_limits_if_master_env(self, app):
+        with override_config(app, 'JOB_SCHEDULING_ENABLED', True):
+            os.environ['EB_ENVIRONMENT'] = 'nessie-master-bee'
+            factory.configure_scheduler_mode(app)
+            assert app.config['JOB_SCHEDULING_ENABLED'] is True
+            assert app.config['WORKER_QUEUE_ENABLED'] is False


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-235

This should let us enable background-thread pools on Nessie-worker instances while letting Nessie-master proceed By All Threads Necessary.