### PR TITLE
[NS-244] Glue externals to nessie and Create LRS glue background job, pyspark caliper etl scripts and caliper schema templates.

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -115,6 +115,17 @@ LRS_INCREMENTAL_DESTINATION_BUCKETS = ['bucket', 'list']
 LRS_INCREMENTAL_DESTINATION_PATH = 'lrs/destination/path'
 LRS_INCREMENTAL_ETL_PATH_REDSHIFT = 'lrs/etl/path/redshift'
 
+LRS_CANVAS_CALIPER_SCHEMA_PATH = 'lrs/path/to/caliper/schema'
+LRS_CANVAS_CALIPER_INPUT_DATA_PATH = 'lrs/input/data/s3/location'
+LRS_CANVAS_CALIPER_EXPLODE_OUTPUT_PATH = 'lrs/glue/output/s3/location'
+
+LRS_CANVAS_GLUE_JOB_NAME = 'job_name_env'
+LRS_CANVAS_GLUE_JOB_CAPACITY = 2
+LRS_CANVAS_GLUE_JOB_TIMEOUT = 20
+LRS_CANVAS_GLUE_JOB_SCRIPT_PATH = 's3://<bucket>/path/to/glue/script'
+LRS_GLUE_TEMP_DIR = 'glue/temp/dir'
+LRS_GLUE_SERVICE_ROLE = 'glue-service-role-name'
+
 LOCH_S3_BUCKET = 'bucket_name'
 LOCH_S3_REGION = 'us-west-2'
 

--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -32,6 +32,7 @@ from nessie.jobs.background_job import ChainedBackgroundJob
 from nessie.jobs.create_calnet_schema import CreateCalNetSchema
 from nessie.jobs.create_canvas_schema import CreateCanvasSchema
 from nessie.jobs.create_coe_schema import CreateCoeSchema
+from nessie.jobs.create_lrs_glue_jobs import CreateLrsGlueJobs
 from nessie.jobs.create_sis_schema import CreateSisSchema
 from nessie.jobs.generate_asc_profiles import GenerateAscProfiles
 from nessie.jobs.generate_boac_analytics import GenerateBoacAnalytics
@@ -49,6 +50,7 @@ from nessie.jobs.import_term_gpas import ImportTermGpas
 from nessie.jobs.resync_canvas_snapshots import ResyncCanvasSnapshots
 from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 from nessie.jobs.sync_file_to_s3 import SyncFileToS3
+from nessie.jobs.transform_lrs_incrementals import TransformLrsIncrementals
 from nessie.lib.http import tolerant_jsonify
 from nessie.lib.metadata import update_canvas_sync_status
 
@@ -159,6 +161,20 @@ def import_lrs_incrementals():
     else:
         truncate_lrs = False
     job_started = ImportLrsIncrementals(truncate_lrs=truncate_lrs).run_async()
+    return respond_with_status(job_started)
+
+
+@app.route('/api/job/create_lrs_glue_jobs', methods=['POST'])
+@auth_required
+def create_lrs_glue_jobs():
+    job_started = CreateLrsGlueJobs().run_async()
+    return respond_with_status(job_started)
+
+
+@app.route('/api/job/transform_lrs_incrementals', methods=['POST'])
+@auth_required
+def transform_lrs_incrementals():
+    job_started = TransformLrsIncrementals().run_async()
     return respond_with_status(job_started)
 
 

--- a/nessie/externals/glue.py
+++ b/nessie/externals/glue.py
@@ -1,0 +1,123 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+"""Client code to run AWS Glue operations."""
+
+
+import boto3
+from flask import current_app as app
+
+
+def get_client():
+    return boto3.client(
+        service_name='glue',
+        aws_access_key_id=app.config['AWS_ACCESS_KEY_ID'],
+        aws_secret_access_key=app.config['AWS_SECRET_ACCESS_KEY'],
+        region_name=app.config['LOCH_S3_REGION'],
+        endpoint_url='https://glue.{}.amazonaws.com'.format(app.config['LOCH_S3_REGION']),
+    )
+
+
+def create_glue_job(name, glue_role, job_command_params, glue_job_args, allocated_capacity=2, timeout=20):
+    client = get_client()
+    response = client.create_job(
+        Name=name,
+        Role=glue_role,
+        Command=job_command_params,
+        DefaultArguments=glue_job_args,
+        AllocatedCapacity=allocated_capacity,
+        Timeout=timeout,
+    )
+    return response
+
+
+def start_glue_job(glue_job_name, glue_job_args, glue_job_capacity):
+    client = get_client()
+    response = client.start_job_run(
+        JobName=glue_job_name,
+        Arguments=glue_job_args,
+        AllocatedCapacity=glue_job_capacity,
+    )
+    return response
+
+
+def get_job(job_name):
+    client = get_client()
+    response = client.get_job(
+        JobName=job_name,
+    )
+    return response
+
+
+def get_jobs():
+    client = get_client()
+    response = client.get_jobs(
+        MaxResults=20,
+    )
+    return response
+
+
+def get_job_runs(job_name):
+    client = get_client()
+    response = client.get_job_runs(
+        JobName=job_name,
+        MaxResults=10,
+    )
+    return response
+
+
+def check_glue_job_run_status(job_name, job_run_id):
+    client = get_client()
+    response = client.get_job_run(
+        JobName=job_name,
+        RunId=job_run_id,
+        PredecessorsIncluded=False,
+    )
+    return response
+
+
+def batch_stop_job_runs(job_name, job_run_ids):
+    client = get_client()
+    response = client.batch_stop_job_run(
+        JobName=job_name,
+        JobRunIds=job_run_ids,
+    )
+    return response
+
+
+def delete_glue_job(job_name):
+    client = get_client()
+    response = client.delete_job(JobName=job_name)
+    return response
+
+
+def update_glue_job(job_name, job_args):
+    client = get_client()
+    response = client.update_job(
+        JobName=job_name,
+        JobUpdate=job_args,
+    )
+    return response

--- a/nessie/jobs/create_lrs_glue_jobs.py
+++ b/nessie/jobs/create_lrs_glue_jobs.py
@@ -1,0 +1,68 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+"""Logic for transforming LRS Caliper statements."""
+
+
+from flask import current_app as app
+from nessie.externals import glue
+from nessie.jobs.background_job import BackgroundJob
+
+
+class CreateLrsGlueJobs(BackgroundJob):
+
+    def run(self):
+        app.logger.info('Create Glue job to process on LRS incrementals')
+        if self.create_lrs_caliper_relationalize_job():
+            return True
+        else:
+            return False
+
+    def create_lrs_caliper_relationalize_job(self):
+        job_name = app.config['LRS_CANVAS_GLUE_JOB_NAME']
+        glue_role = app.config['LRS_GLUE_SERVICE_ROLE']
+        job_command = {
+            'Name': 'glueetl',
+            'ScriptLocation': 's3://{}/{}'.format(app.config['LRS_INCREMENTAL_TRANSIENT_BUCKET'], app.config['LRS_CANVAS_GLUE_JOB_SCRIPT_PATH']),
+        }
+        default_arguments = {
+            '--LRS_INCREMENTAL_TRANSIENT_BUCKET': app.config['LRS_INCREMENTAL_TRANSIENT_BUCKET'],
+            '--LRS_CANVAS_CALIPER_SCHEMA_PATH': app.config['LRS_CANVAS_CALIPER_SCHEMA_PATH'],
+            '--LRS_CANVAS_CALIPER_INPUT_DATA_PATH': app.config['LRS_CANVAS_CALIPER_INPUT_DATA_PATH'],
+            '--LRS_GLUE_TEMP_DIR': app.config['LRS_GLUE_TEMP_DIR'],
+            '--LRS_CANVAS_CALIPER_EXPLODE_OUTPUT_PATH': app.config['LRS_CANVAS_CALIPER_EXPLODE_OUTPUT_PATH'],
+        }
+
+        response = glue.create_glue_job(job_name, glue_role, job_command, default_arguments)
+        if not response:
+            app.logger.error('Failed to create Glue job')
+            return False
+        elif response['Name']:
+            app.logger.info(f'Response : {response}')
+            app.logger.info(f'Glue Job created successfully with Job Name : {response}')
+            return True
+        else:
+            return False

--- a/nessie/jobs/transform_lrs_incrementals.py
+++ b/nessie/jobs/transform_lrs_incrementals.py
@@ -1,0 +1,38 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+"""Logic for transforming LRS Caliper statements."""
+
+
+from flask import current_app as app
+# from nessie.externals import glue, redshift, s3
+from nessie.jobs.background_job import BackgroundJob
+
+
+class TransformLrsIncrementals(BackgroundJob):
+
+    def run(self):
+        app.logger.info('Starting ETL process on LRS incrementals...')

--- a/nessie/sql_templates/glue_templates/caliper_input_schema.json
+++ b/nessie/sql_templates/glue_templates/caliper_input_schema.json
@@ -1,0 +1,989 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "@context",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "action",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "actor",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "extensions",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "com.instructure.canvas",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "entity_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "real_user_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "root_account_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "root_account_lti_guid",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "root_account_uuid",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "user_login",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "id",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "type",
+            "nullable": true,
+            "type": "string"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "edApp",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "id",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "type",
+            "nullable": true,
+            "type": "string"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "eventTime",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "extensions",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "com.instructure.canvas",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "hostname",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "job_id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "job_tag",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "request_id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "user_agent",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "version",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "generated",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "attempt",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "assignable",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "type",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                },
+                {
+                  "metadata": {},
+                  "name": "assignee",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "type",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                },
+                {
+                  "metadata": {},
+                  "name": "extensions",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "com.instructure.canvas",
+                        "nullable": true,
+                        "type": {
+                          "fields": [
+                            {
+                              "metadata": {},
+                              "name": "grade",
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          ],
+                          "type": "struct"
+                        }
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                },
+                {
+                  "metadata": {},
+                  "name": "id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "type",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "extensions",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "com.instructure.canvas",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "entity_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "grade",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "id",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "maxScore",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "scoreGiven",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "scoredBy",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "type",
+            "nullable": true,
+            "type": "string"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "group",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "extensions",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "com.instructure.canvas",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "context_type",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "entity_id",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "id",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "type",
+            "nullable": true,
+            "type": "string"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "id",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "membership",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "id",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "member",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "type",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "organization",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "subOrganizationOf",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "type",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                },
+                {
+                  "metadata": {},
+                  "name": "type",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "roles",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "type",
+            "nullable": true,
+            "type": "string"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "object",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "assignable",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "type",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "assignee",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "type",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "body",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "count",
+            "nullable": true,
+            "type": "long"
+          },
+          {
+            "metadata": {},
+            "name": "creators",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "dateCreated",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "dateModified",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "dateToShow",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "dateToSubmit",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "description",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "extensions",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "com.instructure.canvas",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "access_is_current",
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "asset_subtype",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "asset_type",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "body",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "context_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "context_type",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "course_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "course_section_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "entity_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "filename",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "folder_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "grade",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "is_admin",
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "is_announcement",
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "limit_privileges_to_course_section",
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "lock_at",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "redirect_url",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "restricted_access",
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "state",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "state_is_current",
+                        "nullable": true,
+                        "type": "boolean"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "state_valid_until",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "submission_type",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "type",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "url",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "user_id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "user_name",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "workflow_state",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "id",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "isPartOf",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "name",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "type",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "maxScore",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "mediaType",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "member",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "type",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "name",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "organization",
+            "nullable": true,
+            "type": {
+              "fields": [
+                {
+                  "metadata": {},
+                  "name": "extensions",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "com.instructure.canvas",
+                        "nullable": true,
+                        "type": {
+                          "fields": [
+                            {
+                              "metadata": {},
+                              "name": "entity_id",
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          ],
+                          "type": "struct"
+                        }
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                },
+                {
+                  "metadata": {},
+                  "name": "id",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "isPartOf",
+                  "nullable": true,
+                  "type": {
+                    "fields": [
+                      {
+                        "metadata": {},
+                        "name": "id",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "name",
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      {
+                        "metadata": {},
+                        "name": "type",
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    ],
+                    "type": "struct"
+                  }
+                },
+                {
+                  "metadata": {},
+                  "name": "name",
+                  "nullable": true,
+                  "type": "string"
+                },
+                {
+                  "metadata": {},
+                  "name": "type",
+                  "nullable": true,
+                  "type": "string"
+                }
+              ],
+              "type": "struct"
+            }
+          },
+          {
+            "metadata": {},
+            "name": "roles",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "startedAtTime",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "type",
+            "nullable": true,
+            "type": "string"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "session",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "id",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "type",
+            "nullable": true,
+            "type": "string"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "timestamp",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "type",
+      "nullable": true,
+      "type": "string"
+    }
+  ],
+  "type": "struct"
+}

--- a/nessie/sql_templates/glue_templates/caliper_transforms.py
+++ b/nessie/sql_templates/glue_templates/caliper_transforms.py
@@ -1,0 +1,115 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import json
+import sys
+from awsglue.context import GlueContext
+from awsglue.dynamicframe import DynamicFrame
+from awsglue.job import Job
+from awsglue.utils import getResolvedOptions
+import boto3
+from pyspark.context import SparkContext
+from pyspark.sql.types import StructType
+
+
+# Pyspark Glue still uses python 2.7 on the AWS cluster while Nessie is running python on 3.6.
+args = getResolvedOptions(
+    sys.argv,
+    [
+        'JOB_NAME',
+        'LRS_INCREMENTAL_TRANSIENT_BUCKET',
+        'LRS_CANVAS_CALIPER_SCHEMA_PATH',
+        'LRS_CANVAS_CALIPER_INPUT_DATA_PATH',
+        'LRS_GLUE_TEMP_DIR',
+        'LRS_CANVAS_CALIPER_EXPLODE_OUTPUT_PATH',
+    ],
+)
+
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+lrs_transient_bucket = args['LRS_INCREMENTAL_TRANSIENT_BUCKET']
+lrs_glue_temp_dir = args['LRS_GLUE_TEMP_DIR']
+lrs_caliper_schema_path = args['LRS_CANVAS_CALIPER_SCHEMA_PATH']
+lrs_canvas_caliper_input_path = args['LRS_CANVAS_CALIPER_INPUT_DATA_PATH']
+lrs_canvas_caliper_explode_path = args['LRS_CANVAS_CALIPER_EXPLODE_OUTPUT_PATH']
+
+
+# Import prepared canavs caliper json schema and convert to struct type that can be applied to spark dataframe as template
+def import_caliper_schema(bucket, key):
+    s3 = boto3.client('s3', region_name='us-west-2')
+    json_file = s3.get_object(Bucket=bucket, Key=key)
+    json_object = json.load(json_file['Body'])
+    schema_struct = StructType.fromJson(json_object)
+    return schema_struct
+
+
+# Relationalizes spark dataframe and exports to s3
+def relationalize_and_export(statements_df):
+    # convert spark dataframe to glue dynamic frame
+    statement_dynamic_frame = DynamicFrame.fromDF(statements_df, glueContext, 'statement_dynamic_frame')
+    glue_temp_dir = 's3://{}/{}'.format(lrs_transient_bucket, lrs_glue_temp_dir)
+    # transform the dataframe using glue relationalize
+    statement_explode_df = statement_dynamic_frame.relationalize('root', glue_temp_dir)
+    statement_explode_df.keys()
+
+    lrs_explode_output_path = 's3://{}/{}'.format(lrs_transient_bucket, lrs_canvas_caliper_explode_path)
+    # write glue dynamic frame contents to s3 location as compressed json gzip files
+    glueContext.write_dynamic_frame.from_options(
+        frame=statement_explode_df,
+        connection_type='s3',
+        connection_options={'path': lrs_explode_output_path, 'compression': 'gzip'},
+        format='json',
+        transformation_ctx='datasink',
+    )
+    return
+
+
+# Create a caliper schema struct that can be used as a template to create spark dataframes
+# print 'Importing Caliper corrected schema from S3 and convert it to struct type'
+caliper_schema_struct = import_caliper_schema(
+    args['LRS_INCREMENTAL_TRANSIENT_BUCKET'],
+    args['LRS_CANVAS_CALIPER_SCHEMA_PATH'],
+)
+
+# Apply prepared schema template on the incoming statements to create a spark dataframe
+sys.stdout.write('Importing Caliper statements from S3 with the corrected schema')
+lrs_caliper_input_data_path = 's3://{}/{}'.format(lrs_transient_bucket, lrs_canvas_caliper_input_path)
+statements_df = spark.read.schema(caliper_schema_struct).json(lrs_caliper_input_data_path)
+statements_df.printSchema()
+
+# Verify inferred schema from spark process.
+sys.stdout.write('Display inferred schema from the dataframe')
+schema_json = statements_df.schema.json()
+sys.stdout.write(schema_json)
+
+# Convert the data to flat tables and export to S3 as compressed json gzip files.
+sys.stdout.write('Exporting dynamic frame as json partitions in S3')
+relationalize_and_export(statements_df)
+
+job.commit()


### PR DESCRIPTION
Commit contains the following:
	1.	Glue external based on boto3 for nessie
	2.	Nessie create lrs glue job
	3.	API routes for triggering create lrs glue job
	4.	Glue templates containing the pyspark scripts to run to explode canvas caliper incremental into flat files
	5.	Glue template having curated canvas caliper schema to recognize the shape of various caliper events to resolve spark dataframe before spark explode operations.
	6.	Configuration file updates required to run Glue jobs.
