### PR TITLE
NS-249, buildspec, for CodePipeline, needs @vue/cli in order to run build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,6 +18,7 @@ phases:
 
   build:
     commands:
+      - npm install -g @vue/cli
       - npm run build-vue
 
   post_build:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-249

CodePipeline no happy:
```
Phase complete: BUILD Success: false
Phase context status code: COMMAND_EXECUTION_ERROR Message: 
  Error while executing command: npm run build-vue. Reason: exit status 1
```