### PR TITLE
NS-249, sudo is required on npm install

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,8 +18,8 @@ phases:
 
   build:
     commands:
-      - npm install -g @vue/cli
-      - npm run build-vue
+      - sudo npm install -g @vue/cli
+      - sudo npm run build-vue
 
   post_build:
     commands:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-249

One last `sudo` tweak. CodePipeline succeeded pulling from this branch. Vue.js homepage is now loading at https://app-master-dev.ets-berkeley-nessie.net/ 