### PR TITLE
BOAC-1272 Calculate against unique scores for optimal matrix spread

### DIFF
--- a/nessie/lib/analytics.py
+++ b/nessie/lib/analytics.py
@@ -32,6 +32,7 @@ from flask import current_app as app
 from nessie.lib import queries
 from numpy import nan
 import pandas
+from scipy.stats import percentileofscore
 
 
 def merge_analytics_for_user(user_courses, canvas_user_id, relative_submission_counts, canvas_site_map):
@@ -165,10 +166,14 @@ def analytics_for_column(df, student_row, column_name):
 
     column_zscore = zscore(dfcol, column_value)
     comparative_percentile = zptile(column_zscore)
+    # For purposes of matrix plotting, improve visual spread by calculating percentile against a range of unique scores.
+    unique_scores = dfcol.unique().tolist()
+    matrixy_comparative_percentile = percentileofscore(unique_scores, column_value, kind='strict')
 
     course_mean = dfcol.mean()
     if course_mean and not math.isnan(course_mean):
         comparative_percentile_of_mean = zptile(zscore(dfcol, course_mean))
+        matrixy_comparative_percentile_of_mean = percentileofscore(unique_scores, course_mean, kind='strict')
     else:
         comparative_percentile_of_mean = None
 
@@ -176,12 +181,14 @@ def analytics_for_column(df, student_row, column_name):
     return {
         'boxPlottable': box_plottable,
         'student': {
+            'matrixyPercentile': matrixy_comparative_percentile,
             'percentile': comparative_percentile,
             'raw': raw_value,
             'roundedUpPercentile': intuitive_percentile,
         },
         'courseDeciles': column_quantiles,
         'courseMean': {
+            'matrixyPercentile': matrixy_comparative_percentile_of_mean,
             'percentile': comparative_percentile_of_mean,
             'raw': course_mean,
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ ldap3==2.5.1
 psycopg2==2.7.5
 pytz==2018.5
 requests==2.20.0
+scipy==1.1.0
 simplejson==3.16.0
 xmltodict==0.11.0
 # ETS fork of https://github.com/RaRe-Technologies/smart_open, with added support for S3 upload arguments.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1272

This is functionally @paulkerschen 's https://github.com/paulkerschen/nessie/commit/458f2bfe5133a31e51eed83c5715d53933b50213 work. My only change was to keep the old percentile property alongside the new one instead of replacing it. I didn't want to foist credit for the corny name on him, though.