### PR TITLE
BOAC-1272 Calculate against unique scores for optimal matrix spread

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ ldap3==2.5.1
 psycopg2==2.7.5
 pytz==2018.5
 requests==2.20.0
+scipy==1.1.0
 simplejson==3.16.0
 xmltodict==0.11.0
 # ETS fork of https://github.com/RaRe-Technologies/smart_open, with added support for S3 upload arguments.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1272

This is functionally Paul Kerschen's https://github.com/paulkerschen/nessie/commit/458f2bfe5133a31e51eed83c5715d53933b50213

My only changes were to keep the old percentile property alongside the new one, and to add a display percentile to the course mean.

I'll wait to submit the corresponding BOAC PR until after this gets a chance to run.