### PR TITLE
BOAC-1272 Change incorrect Mean Man display percentile

### DIFF
--- a/nessie/lib/analytics.py
+++ b/nessie/lib/analytics.py
@@ -174,8 +174,11 @@ def analytics_for_column(df, student_row, column_name):
     if course_mean and not math.isnan(course_mean):
         # Spoiler: this will be '50.0'.
         comparative_percentile_of_mean = zptile(zscore(dfcol, course_mean))
+        # This may or may not be the best choice. On the plus side, it emphasizes that this dot represents the mean.
+        # On the minus, when there is a small number of unique values, the dot will be cheek-by-jowl with
+        # real students who have higher displayed percentiles.
+        intuitive_percentile_of_mean = comparative_percentile_of_mean
         matrixy_comparative_percentile_of_mean = percentileofscore(unique_scores, course_mean, kind='strict')
-        intuitive_percentile_of_mean = int(percentileofscore(unique_scores, course_mean, kind='weak'))
     else:
         comparative_percentile_of_mean = None
         matrixy_comparative_percentile_of_mean = None


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1272

Correction to https://github.com/ets-berkeley-edu/nessie/pull/263 , which sometimes claimed that the Mean Man was in the "30th" percentile, etc.