### PR TITLE
NS-299, 'npm run build-vue' failed due to improper vue-lodash import

### DIFF
--- a/src/components/Jobs.vue
+++ b/src/components/Jobs.vue
@@ -96,11 +96,12 @@ export default {
       });
     },
     runSelectedJob() {
+      /* eslint no-undef: "warn" */
       let apiPath = this.runnableJob.selected.path;
-      this._.each(
+      _.each(
         this.runnableJob.selected.requiredParameters,
         (requiredParameter, index) => {
-          apiPath = this._.replace(
+          apiPath = _.replace(
             apiPath,
             '<' + requiredParameter + '>',
             this.runnableJob.params[index]

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import 'bootstrap-vue/dist/bootstrap-vue.min.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import App from '@/App.vue';
 import Vue from 'vue';
-import VueLodash from 'vue-lodash';
 import axios from 'axios';
 import BootstrapVue from 'bootstrap-vue';
 import router from '@/router';
@@ -18,7 +17,7 @@ axios.interceptors.response.use(response => response, function(error) {
 Vue.config.productionTip = false;
 Vue.use(BootstrapVue);
 Vue.use(require('vue-moment'));
-Vue.use(VueLodash);
+Vue.use(require('vue-lodash'), { name: '_' });
 
 new Vue({
   router,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-299

`npm run build-vue` has stricter standards compared to `npm run serve` (used for local dev). The inline "eslint:warn" will be addressed later.