### PR TITLE
[QA] BOAC-1431 Allow fallback to yesterday's Canvas data in external schema

### DIFF
--- a/nessie/lib/util.py
+++ b/nessie/lib/util.py
@@ -81,8 +81,8 @@ def get_s3_calnet_daily_path(cutoff=None):
     return app.config['LOCH_S3_CALNET_DATA_PATH'] + '/daily/' + hashed_datestamp(cutoff)
 
 
-def get_s3_canvas_daily_path():
-    return app.config['LOCH_S3_CANVAS_DATA_PATH_DAILY'] + '/' + hashed_datestamp()
+def get_s3_canvas_daily_path(cutoff=None):
+    return app.config['LOCH_S3_CANVAS_DATA_PATH_DAILY'] + '/' + hashed_datestamp(cutoff)
 
 
 def get_s3_coe_daily_path(cutoff=None):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1431

It's always midnight somewhere.

QA-first PR because the qa tier is where it needs to be tried out. This pattern already exists in nessie/jobs/create_sis_schema.py, and probably should have been ported over here before now.