### PR TITLE
NOJIRA Replace some TypeScript punts; fix linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,10 +11,12 @@ module.exports = {
     'eslint:recommended',
     'plugin:vue/essential'
   ],
-  plugins: ['vue', 'prettier'],
+  plugins: ['vue', 'prettier', 'typescript'],
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    // eslint-plugin-typescript does not currently recognize interfaces as 'used' in parameter typing.
+    'typescript/no-unused-vars': 'warn',
     'prettier/prettier': [
       'error',
       {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import VueRouter from 'vue-router';
+import VueRouter, { Route } from 'vue-router';
 import store from '@/store';
 import { getRunnableJobs } from '@/api/job';
 import { getMyProfile } from '@/api/user';
@@ -25,8 +25,8 @@ let registerMe = () => {
   );
 };
 
-let beforeEach = (to: any, from: any, next: any) => {
-  let safeNext = (to: any, next: any) => {
+let beforeEach = (to: Route, from: Route, next: Function) => {
+  let safeNext = (to: Route, next: Function) => {
     if (to.matched.length) {
       next();
     } else {
@@ -40,7 +40,7 @@ let beforeEach = (to: any, from: any, next: any) => {
   }
 };
 
-let requiresAuth = (to: any, from: any, next: any) => {
+let requiresAuth = (to: Route, from: Route, next: Function) => {
   if (store.getters.user) {
     next();
   } else {
@@ -55,7 +55,7 @@ const router = new VueRouter({
       path: '/login',
       name: 'login',
       component: Login,
-      beforeEnter: (to: any, from: any, next: any) => {
+      beforeEnter: (to: Route, from: Route, next: Function) => {
         if (store.getters.user) {
           next('/home');
         } else {

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,33 +11,33 @@ const state = {
 };
 
 const getters = {
-  errors: (state: any) => {
+  errors: state => {
     return state.errors;
   },
-  runnableJobs: (state: any) => {
+  runnableJobs: state => {
     return state.runnableJobs;
   },
-  user: (state: any) => {
+  user: state => {
     return state.user;
   }
 };
 
 const mutations = {
-  logout: (state: any) => {
+  logout: state => {
     state.user = null;
   },
-  registerMe: (state: any, user: any) => {
+  registerMe: (state, user) => {
     state.user = user;
   },
-  cacheRunnableJobs: (state: any, runnableJobs: any) => {
+  cacheRunnableJobs: (state, runnableJobs) => {
     state.runnableJobs = runnableJobs;
   },
-  reportError: (state: any, error: any) => {
+  reportError: (state, error) => {
     error.id = new Date().getTime();
     state.errors.push(error);
   },
-  dismissError: (state: any, id: number) => {
-    const indexOf = state.errors.findIndex((e: any) => e.id === id);
+  dismissError: (state, id: number) => {
+    const indexOf = state.errors.findIndex(e => e.id === id);
     if (indexOf > -1) {
       state.errors.splice(indexOf, 1);
     }


### PR DESCRIPTION
Following up on a discussion with @johncrossman & @lyttam (which would've also included @paulkerschen if he'd been available)...

Nessie/BOA's wee bit of TypeScript code includes some explicit function-parameter typing of "any" even though the code clearly does expect an object with a predictable structure.

None of us are eager to relive the full-on interface/class Java experience. But the newer JS frameworks push TS hard, and if we're going to use it, it would be nice to trim the noise. So we'll try this:

* Fill in more real-types when it's easy (e.g., this PR).
* Instead of explicitly defaulting all arguments to "any", we will leave them explicitly _untyped_, which in turn means continuing to disable "noImplicitAny" checks. That way it'll be easy to see which typing has been thought out by a developer and which typing hasn't been handled yet.