### PR TITLE
NS-331 Avoid scheduling conflicts between the final two BOA jobs

### DIFF
--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -134,8 +134,6 @@ def generate_intermediate_tables():
 @app.route('/api/job/generate_merged_student_feeds/<term_id>', methods=['POST'])
 @auth_required
 def generate_merged_student_feeds(term_id):
-    if term_id == 'all':
-        term_id = None
     args = get_json_args(request)
     if args:
         backfill = args.get('backfill')

--- a/nessie/jobs/generate_merged_student_feeds.py
+++ b/nessie/jobs/generate_merged_student_feeds.py
@@ -51,7 +51,12 @@ class GenerateMergedStudentFeeds(BackgroundJob):
     staging_schema = destination_schema + '_staging'
     staging_schema_identifier = psycopg2.sql.Identifier(staging_schema)
 
-    def run(self, term_id=None, backfill_new_students=False):
+    def run(self, term_id=None, backfill_new_students=True):
+        if not term_id:
+            term_id = berkeley.current_term_id()
+        elif term_id == 'all':
+            term_id = None
+
         app.logger.info(f'Starting merged profile generation job (term_id={term_id}, backfill={backfill_new_students}).')
 
         app.logger.info('Cleaning up old data...')

--- a/nessie/jobs/scheduling.py
+++ b/nessie/jobs/scheduling.py
@@ -27,7 +27,6 @@ import os
 
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.background import BackgroundScheduler
-from nessie.lib.berkeley import current_term_id
 
 """Background job scheduling."""
 
@@ -130,15 +129,15 @@ def schedule_all_jobs(force=False):
         ],
         force,
     )
-    schedule_job(
+    schedule_chained_job(
         sched,
         'JOB_GENERATE_CURRENT_TERM_FEEDS',
-        GenerateMergedStudentFeeds,
+        [
+            GenerateMergedStudentFeeds,
+            RefreshBoacCache,
+        ],
         force,
-        term_id=current_term_id(),
-        backfill_new_students=True,
     )
-    schedule_job(sched, 'JOB_REFRESH_BOAC_CACHE', RefreshBoacCache, force)
 
 
 def add_job(sched, job_func, job_arg, job_id, force=False, **job_opts):

--- a/tests/test_api/test_schedule_controller.py
+++ b/tests/test_api/test_schedule_controller.py
@@ -42,7 +42,7 @@ class TestGetSchedule:
     def test_get_schedule(self, app, client):
         """Returns job schedule based on default config values."""
         jobs = client.get('/api/schedule').json
-        assert len(jobs) == 10
+        assert len(jobs) == 9
         for job in jobs:
             assert job['locked'] is False
         assert next(job for job in jobs if job['id'] == 'job_sync_canvas_snapshots')
@@ -96,7 +96,7 @@ class TestUpdateSchedule:
         )
         assert response.status_code == 200
         jobs = response.json
-        assert len(jobs) == 10
+        assert len(jobs) == 9
         sync_job = next(job for job in jobs if job['id'] == 'job_sync_canvas_snapshots')
         assert sync_job['trigger'] == "cron[hour='1', minute='0']"
         resync_job = next(job for job in jobs if job['id'] == 'job_resync_canvas_snapshots')
@@ -154,19 +154,3 @@ class TestUpdateSchedule:
         assert response.status_code == 200
         assert response.json['trigger'] == "cron[hour='1', minute='0']"
         assert '01:00:00' in response.json['nextRun']
-
-    def test_update_job_args(self, app, client, scheduler):
-        """Updates job args."""
-        jobs = client.get('/api/schedule').json
-        feed_job = next(j for j in jobs if j['id'] == 'job_generate_current_term_feeds')
-        assert feed_job['args'] == {'backfill_new_students': True, 'term_id': '2178'}
-        response = post_basic_auth(
-            client,
-            '/api/schedule/job_generate_current_term_feeds/args',
-            credentials(app),
-            {'term_id': '2182'},
-        )
-        assert response.status_code == 200
-        jobs = client.get('/api/schedule').json
-        feed_job = next(j for j in jobs if j['id'] == 'job_generate_current_term_feeds')
-        assert feed_job['args'] == {'backfill_new_students': True, 'term_id': '2182'}


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-331

Required flipping GenerateMergedStudentFeeds defaults to match the nightly job.

Since these scheduling conflicts have been hitting production for a while, if this change tests out I think it should probably go into the QA branch as well. 