### PR TITLE
NS-319 Retrieve dropped sections for all terms rather than looping

### DIFF
--- a/nessie/lib/queries.py
+++ b/nessie/lib/queries.py
@@ -112,12 +112,11 @@ def get_enrolled_primary_sections_for_term(term_id):
 
 
 @fixture('query_enrollment_drops_{csid}.csv')
-def get_enrollment_drops(csid, term_id):
+def get_enrollment_drops(csid):
     sql = f"""SELECT dr.*
               FROM {intermediate_schema()}.sis_dropped_classes AS dr
               WHERE dr.sid = '{csid}'
-                AND dr.sis_term_id = '{term_id}'
-              ORDER BY dr.sis_course_name
+              ORDER BY dr.sis_term_id DESC, dr.sis_course_name
             """
     return redshift.fetch(sql)
 
@@ -143,7 +142,7 @@ def get_sis_enrollments(uid):
                   ON crs.sis_section_id = enr.sis_section_id
                   AND crs.sis_term_id = enr.sis_term_id
               WHERE enr.ldap_uid = {uid}
-              ORDER BY enr.sis_term_id, crs.sis_course_name, crs.sis_primary DESC, crs.sis_instruction_format, crs.sis_section_num
+              ORDER BY enr.sis_term_id DESC, crs.sis_course_name, crs.sis_primary DESC, crs.sis_instruction_format, crs.sis_section_num
         """
     return redshift.fetch(sql)
 

--- a/nessie/sql_templates/create_intermediate_schema.template.sql
+++ b/nessie/sql_templates/create_intermediate_schema.template.sql
@@ -58,7 +58,8 @@ AS (
  */
 
 CREATE TABLE {redshift_schema_intermediate}.sis_dropped_classes
-INTERLEAVED SORTKEY (sis_term_id, sid)
+DISTKEY (sid)
+SORTKEY (sid)
 AS (
     SELECT
         en.term_id AS sis_term_id,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-319

The easiest prospective improvement.

PR also includes some refactoring to more plainly distinguish current-profile generation from enrollments-feed generation.