### PR TITLE
NS-309 Caliper transformation: adjust tolerance for timestamp sanity check

### DIFF
--- a/nessie/jobs/generate_canvas_caliper_analytics.py
+++ b/nessie/jobs/generate_canvas_caliper_analytics.py
@@ -93,7 +93,7 @@ class GenerateCanvasCaliperAnalytics(BackgroundJob):
         if not earliest_untransformed or not latest_transformed:
             return False
         timestamp_diff = (earliest_untransformed - latest_transformed).total_seconds()
-        if timestamp_diff < 0 or timestamp_diff > 300:
+        if timestamp_diff < -60 or timestamp_diff > 300:
             app.logger.error(
                 f'Unexpected difference between Caliper timestamps: latest transformed {latest_transformed}, '
                 f'earliest untransformed {earliest_untransformed}',


### PR DESCRIPTION
News flash, kid: in the real world your timestamps don't always arrive in perfect order.

https://jira.ets.berkeley.edu/jira/browse/NS-309