### PR TITLE
NS-379 Improve the verification scheme for the generated data catalog

### DIFF
--- a/nessie/externals/redshift.py
+++ b/nessie/externals/redshift.py
@@ -95,13 +95,13 @@ def copy_tsv_from_s3(table, s3_key):
 
 
 def create_external_schema(external_schema, role):
-    query = """
+    query = f"""
         CREATE EXTERNAL SCHEMA {external_schema}
         FROM data catalog
         DATABASE '{external_schema}'
-        IAM_ROLE '{redshift_iam_role}'
+        IAM_ROLE '{role}'
         CREATE EXTERNAL DATABASE IF NOT EXISTS;
-        """.format(external_schema, role)
+        """
 
     if not execute(query):
         app.logger.error('Error on Redshift create schema')


### PR DESCRIPTION
The PR contains the following logic,

1) get an inventory of all S3 objects in a prefix for canvas-data.
2) Isolate unique table names from the s3 objects  extracted from the daily location
3) Run data verification processes to identify bad migration scenarios 

The logic ensures that all the canvas-data files sync are cataloged and verified. Tables for which schema exist but there is no data are omitted in the process.

https://jira.ets.berkeley.edu/jira/browse/NS-379 