### PR TITLE
NS-457, convert legacy note timestamps to proper UTC

### DIFF
--- a/tests/test_lib/test_util.py
+++ b/tests/test_lib/test_util.py
@@ -32,3 +32,17 @@ class TestUtil:
     def test_vacuum_whitespace(self):
         """Cleans up leading, trailing, and repeated whitespace."""
         assert util.vacuum_whitespace('  Firstname    Lastname   ') == 'Firstname Lastname'
+
+    def test_legacy_note_datetime_to_utc(self, app):
+        for expect_none in (None, '  ', '+00', 'garbled date'):
+            assert util.legacy_note_datetime_to_utc(expect_none) is None, f'Failed on input: \'{expect_none}\''
+
+        utc = util.legacy_note_datetime_to_utc('2016-12-14 06:17:08.821896+00')
+        assert utc
+        assert utc.tzinfo.zone == 'UTC'
+        assert f'{utc.year}-{utc.month}-{utc.day} {utc.hour}:{utc.minute}:0{utc.second}' == '2016-12-14 14:17:08'
+
+        utc = util.legacy_note_datetime_to_utc('2016-12-16 23:59:30+00')
+        assert utc
+        assert utc.tzinfo.zone == 'UTC'
+        assert f'{utc.year}-{utc.month}-{utc.day} 0{utc.hour}:{utc.minute}:{utc.second}' == '2016-12-17 07:59:30'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-457

We have 504,956 legacy notes. For now, this job is run as needed but suggestions on improving performance are welcome. Can _bulk_ RDS updates be made with current `psycopg`? 