### PR TITLE
NS-540: Points to new S3 location for historical SIS notes

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -141,7 +141,7 @@ LOCH_EDX_S3_TRANSACTION_LOG_PATH = 'path/to/edx/transaction/log'
 
 # Loch Nessie configs
 LOCH_S3_BUCKET = 'bucket_name'
-LOCH_S3_SIS_ADVISING_NOTES_BUCKET = 'advising notes bucket name'
+LOCH_S3_PROTECTED_BUCKET = 'advising notes bucket name'
 LOCH_S3_REGION = 'us-west-2'
 
 LOCH_S3_CANVAS_DATA_PATH_CURRENT_TERM = 'canvas/path/to/current/term'
@@ -155,7 +155,6 @@ LOCH_S3_BOAC_ANALYTICS_DATA_PATH = 'boac-analytics'
 LOCH_S3_CALNET_DATA_PATH = 'calnet-data'
 LOCH_S3_COE_DATA_PATH = 'coe-data'
 LOCH_S3_PHYSICS_DATA_PATH = 'physics-data'
-LOCH_S3_SIS_ADVISING_NOTES_DATA_PATH = 'sis-advising-notes-data'
 LOCH_S3_SIS_DATA_PATH = 'sis-data'
 LOCH_S3_SIS_API_DATA_PATH = 'sis-api-data'
 

--- a/nessie/lib/util.py
+++ b/nessie/lib/util.py
@@ -103,7 +103,7 @@ def get_s3_sis_api_daily_path(cutoff=None):
 def resolve_sql_template_string(template_string, **kwargs):
     """Our DDL template files are simple enough to use standard Python string formatting."""
     s3_prefix = 's3://' + app.config['LOCH_S3_BUCKET'] + '/'
-    s3_advising_notes_prefix = 's3://' + app.config['LOCH_S3_SIS_ADVISING_NOTES_BUCKET'] + '/'
+    s3_protected_prefix = 's3://' + app.config['LOCH_S3_PROTECTED_BUCKET'] + '/'
     template_data = {
         'rds_app_boa_user': app.config['RDS_APP_BOA_USER'],
         'rds_dblink_to_redshift': app.config['REDSHIFT_DATABASE'] + '_redshift',
@@ -146,9 +146,9 @@ def resolve_sql_template_string(template_string, **kwargs):
         'loch_s3_canvas_data_path_current_term': s3_prefix + app.config['LOCH_S3_CANVAS_DATA_PATH_CURRENT_TERM'],
         'loch_s3_coe_data_path': s3_prefix + get_s3_coe_daily_path(),
         'loch_s3_physics_data_path': s3_prefix + app.config['LOCH_S3_PHYSICS_DATA_PATH'],
-        'loch_s3_sis_advising_notes_data_path': s3_advising_notes_prefix + app.config['LOCH_S3_SIS_ADVISING_NOTES_DATA_PATH'],
         'loch_s3_sis_data_path': s3_prefix + app.config['LOCH_S3_SIS_DATA_PATH'],
         'loch_s3_sis_api_data_path': s3_prefix + get_s3_sis_api_daily_path(),
+        'loch_s3_sis_data_protected_path': s3_protected_prefix + app.config['LOCH_S3_SIS_DATA_PATH'],
     }
     # Kwargs may be passed in to modify default template data.
     template_data.update(kwargs)

--- a/nessie/sql_templates/create_sis_advising_notes_schema.template.sql
+++ b/nessie/sql_templates/create_sis_advising_notes_schema.template.sql
@@ -61,7 +61,7 @@ WITH SERDEPROPERTIES (
   'escapeChar' = '\\'
 )
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_notes'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_notes'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_details (PS_SCI_NOTE_TRNDTL)
@@ -82,7 +82,7 @@ ROW FORMAT DELIMITED
 FIELDS TERMINATED BY '\t'
 LINES TERMINATED BY '\r'
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_details'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_details'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_topics (PS_SCI_NOTE_TOPIC)
@@ -99,7 +99,7 @@ WITH SERDEPROPERTIES (
   'escapeChar' = '\\'
 )
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_topics'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_topics'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_priorities (PS_SCI_NOTE_PRITBL)
@@ -123,7 +123,7 @@ WITH SERDEPROPERTIES (
   'escapeChar' = '\\'
 )
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_priorities'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_priorities'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_attachments (PS_SCI_NOTE_ATTACH)
@@ -149,7 +149,7 @@ WITH SERDEPROPERTIES (
   'escapeChar' = '\\'
 )
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_attachments'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_attachments'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_attachment_data (PS_SCI_FILE_ATT)
@@ -170,7 +170,7 @@ WITH SERDEPROPERTIES (
   'escapeChar' = '\\'
 )
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_attachment_data'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_attachment_data'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_topic_config (PS_SCI_NOTETPC_TBL)
@@ -194,7 +194,7 @@ WITH SERDEPROPERTIES (
   'escapeChar' = '\\'
 )
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_topic_config'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_topic_config'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_templates (PS_SCI_FREENOTETBL)
@@ -214,7 +214,7 @@ ROW FORMAT DELIMITED
 FIELDS TERMINATED BY '\t'
 LINES TERMINATED BY '\r'
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_templates'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_templates'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_categories (PS_SAA_NOTE_TYPE)
@@ -238,7 +238,7 @@ WITH SERDEPROPERTIES (
   'escapeChar' = '\\'
 )
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_categories'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_categories'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 -- advising_note_subcategories (PS_SAA_NOTE_STYPE)
@@ -263,7 +263,7 @@ WITH SERDEPROPERTIES (
   'escapeChar' = '\\'
 )
 STORED AS TEXTFILE
-LOCATION '{loch_s3_sis_advising_notes_data_path}/advising_note_subcategories'
+LOCATION '{loch_s3_sis_data_protected_path}/historical/advising-notes/advising_note_subcategories'
 TABLE PROPERTIES ('skip.header.line.count'='1');
 
 --------------------------------------------------------------------


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-540

The historical snapshot of SIS notes data has been copied to s3://la-nessie-protected-dev/sis-data/historical/advising-notes.  This PR updates the code to point to the new location.  

I also updated the nessie-dev deploy config accordingly.  Once deployed and tested, I'll remove the old S3 folders that will no longer be in use.