### PR TITLE
BOAC-2238: Adds advising note search index to ASC schema

### DIFF
--- a/nessie/sql_templates/create_asc_advising_notes_schema.template.sql
+++ b/nessie/sql_templates/create_asc_advising_notes_schema.template.sql
@@ -66,6 +66,8 @@ DROP SCHEMA IF EXISTS {redshift_schema_asc_advising_notes_internal} CASCADE;
 CREATE SCHEMA {redshift_schema_asc_advising_notes_internal};
 GRANT USAGE ON SCHEMA {redshift_schema_asc_advising_notes_internal} TO GROUP {redshift_app_boa_user}_group;
 ALTER default PRIVILEGES IN SCHEMA {redshift_schema_asc_advising_notes_internal} GRANT SELECT ON TABLES TO GROUP {redshift_app_boa_user}_group;
+GRANT USAGE ON SCHEMA {redshift_schema_asc_advising_notes_internal} TO GROUP {redshift_dblink_group};
+ALTER DEFAULT PRIVILEGES IN SCHEMA {redshift_schema_asc_advising_notes_internal} GRANT SELECT ON TABLES TO GROUP {redshift_dblink_group};
 
 --------------------------------------------------------------------
 -- Internal tables

--- a/nessie/sql_templates/index_asc_advising_notes.template.sql
+++ b/nessie/sql_templates/index_asc_advising_notes.template.sql
@@ -1,0 +1,113 @@
+/**
+ * Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+CREATE SCHEMA IF NOT EXISTS {rds_schema_asc};
+GRANT USAGE ON SCHEMA {rds_schema_asc} TO {rds_app_boa_user};
+ALTER DEFAULT PRIVILEGES IN SCHEMA {rds_schema_asc} GRANT SELECT ON TABLES TO {rds_app_boa_user};
+
+BEGIN TRANSACTION;
+
+DROP TABLE IF EXISTS {rds_schema_asc}.advising_notes CASCADE;
+
+CREATE TABLE {rds_schema_asc}.advising_notes (
+  id VARCHAR NOT NULL,
+  asc_id VARCHAR NOT NULL,
+  sid VARCHAR NOT NULL,
+  student_first_name VARCHAR,
+  student_last_name VARCHAR,
+  meeting_date VARCHAR,
+  advisor_uid VARCHAR,
+  advisor_first_name VARCHAR,
+  advisor_last_name VARCHAR,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  PRIMARY KEY (id)
+);
+
+INSERT INTO {rds_schema_asc}.advising_notes (
+  SELECT * 
+  FROM dblink('{rds_dblink_to_redshift}',$REDSHIFT$
+    SELECT DISTINCT id, asc_id, sid, student_first_name, student_last_name, meeting_date,
+      advisor_uid, advisor_first_name, advisor_last_name, created_at, updated_at
+    FROM {redshift_schema_asc_advising_notes_internal}.advising_notes
+  $REDSHIFT$)
+  AS redshift_notes (
+    id VARCHAR,
+    asc_id VARCHAR,
+    sid VARCHAR,
+    student_first_name VARCHAR,
+    student_last_name VARCHAR,
+    meeting_date VARCHAR,
+    advisor_uid VARCHAR,
+    advisor_first_name VARCHAR,
+    advisor_last_name VARCHAR,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP
+  )
+);
+
+CREATE INDEX idx_asc_advising_notes_sid ON {rds_schema_asc}.advising_notes(sid);
+CREATE INDEX idx_asc_advising_notes_advisor_uid ON {rds_schema_asc}.advising_notes(advisor_uid);
+CREATE INDEX idx_asc_advising_notes_updated_at ON {rds_schema_asc}.advising_notes(updated_at);
+
+DROP TABLE IF EXISTS {rds_schema_asc}.advising_note_topics CASCADE;
+
+CREATE TABLE {rds_schema_asc}.advising_note_topics (
+  id VARCHAR NOT NULL,
+  asc_id VARCHAR NOT NULL,
+  sid VARCHAR NOT NULL,
+  topic VARCHAR NOT NULL,
+  PRIMARY KEY (id, topic)
+);
+
+INSERT INTO {rds_schema_asc}.advising_note_topics (
+  SELECT *
+  FROM dblink('{rds_dblink_to_redshift}',$REDSHIFT$
+    SELECT DISTINCT id, asc_id, sid, topic
+    FROM {redshift_schema_asc_advising_notes_internal}.advising_note_topics
+  $REDSHIFT$)
+  AS redshift_note_topics (
+    id VARCHAR,
+    asc_id VARCHAR,
+    sid VARCHAR,
+    topic VARCHAR
+  )
+);
+
+DROP MATERIALIZED VIEW IF EXISTS {rds_schema_asc}.advising_notes_search_index CASCADE;
+
+CREATE MATERIALIZED VIEW {rds_schema_asc}.advising_notes_search_index AS (
+  SELECT id, to_tsvector('english', topic) AS fts_index
+  FROM {rds_schema_asc}.advising_note_topics
+  UNION
+  SELECT id, to_tsvector('english', advisor_first_name || ' ' || advisor_last_name) AS fts_index
+  FROM {rds_schema_asc}.advising_notes
+);
+
+CREATE INDEX idx_advising_notes_ft_search
+ON {rds_schema_asc}.advising_notes_search_index
+USING gin(fts_index);
+
+COMMIT TRANSACTION;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2238

I thought it made sense to add these tables to the existing `boac_advising_asc` schema, but I could alternatively add them to the `boac_advising_notes` schema or create a new schema for them.