### PR TITLE
BOAC-2435 Add timezone info to RDS advising note indexes

### DIFF
--- a/nessie/sql_templates/index_asc_advising_notes.template.sql
+++ b/nessie/sql_templates/index_asc_advising_notes.template.sql
@@ -41,13 +41,13 @@ CREATE TABLE {rds_schema_asc}.advising_notes (
   advisor_uid VARCHAR,
   advisor_first_name VARCHAR,
   advisor_last_name VARCHAR,
-  created_at TIMESTAMP NOT NULL,
-  updated_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
   PRIMARY KEY (id)
 );
 
 INSERT INTO {rds_schema_asc}.advising_notes (
-  SELECT * 
+  SELECT *
   FROM dblink('{rds_dblink_to_redshift}',$REDSHIFT$
     SELECT DISTINCT id, asc_id, sid, student_first_name, student_last_name, meeting_date,
       advisor_uid, advisor_first_name, advisor_last_name, created_at, updated_at
@@ -68,8 +68,8 @@ INSERT INTO {rds_schema_asc}.advising_notes (
     advisor_uid VARCHAR,
     advisor_first_name VARCHAR,
     advisor_last_name VARCHAR,
-    created_at TIMESTAMP,
-    updated_at TIMESTAMP
+    created_at TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TIME ZONE
   )
 );
 

--- a/nessie/sql_templates/index_sis_advising_notes.template.sql
+++ b/nessie/sql_templates/index_sis_advising_notes.template.sql
@@ -40,8 +40,8 @@ CREATE TABLE {rds_schema_sis_advising_notes}.advising_notes (
   note_subcategory VARCHAR,
   note_body TEXT,
   created_by VARCHAR,
-  created_at TIMESTAMP NOT NULL,
-  updated_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
   PRIMARY KEY (id)
 );
 
@@ -62,8 +62,8 @@ INSERT INTO {rds_schema_sis_advising_notes}.advising_notes (
     note_subcategory VARCHAR,
     note_body TEXT,
     created_by VARCHAR,
-    created_at TIMESTAMP,
-    updated_at TIMESTAMP
+    created_at TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TIME ZONE
   )
 );
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2435

Without this info, locally run BOAC code displayed search results with a timezone shift, neatly obscuring a separate BOAC-side bug (https://github.com/ets-berkeley-edu/boac/pull/1688).