### PR TITLE
Lock down pydocstyle version for linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ deps =
     flake8-strict
     flake8-tidy-imports
     pep8-naming
+    pydocstyle==3.0.0
 
 [flake8]
 exclude =


### PR DESCRIPTION
See also:  https://github.com/ets-berkeley-edu/boac/commit/be837490fdc6b79c3381a84e95f2726c35d9b7ea