### PR TITLE
BOAC-2478, revert psycopg2 to v2.7.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ apscheduler==3.5.1
 boto3==1.7.84
 decorator==4.3.2
 ldap3==2.6
-psycopg2==2.8.3
+psycopg2==2.7.7
 pytz==2019.1
 requests==2.22.0
 scipy==1.1.0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2478

See `psycopg2` error in https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logEventViewer:group=/aws/elasticbeanstalk/nessie-master-dev/var/log/eb-activity.log;stream=i-0933c40f9b543b7b3;start=2019-07-14T18:53:18Z
