### PR TITLE
NS-612 Handle upcoming change to SIS V2 Students API parameter

### DIFF
--- a/nessie/externals/sis_student_api.py
+++ b/nessie/externals/sis_student_api.py
@@ -158,6 +158,7 @@ def _get_v2_by_sids_list(up_to_100_sids, term_id=None, as_of=None, with_registra
         'inc-acad': True,
         'inc-cntc': True,
         'inc-completed-programs': True,
+        'inc-inactive-programs': True,
     }
     if term_id:
         params['term-id'] = term_id
@@ -177,7 +178,7 @@ def _get_v2_single_student(sid, term_id=None, as_of=None):
         'inc-attr': True,
         'inc-cntc': True,
         'inc-completed-programs': True,
-        'inc-incompleted-programs': True,
+        'inc-inactive-programs': True,
         'inc-dmgr': True,
         'inc-gndr': True,
         'inc-regs': True,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-612

The current production release of the V2 Students API returns info on discontinued academic plans when `inc-completed-programs` are requested. But the upcoming release (currently in QA) will require a `inc-inactive-programs=true` parameter as well.