### PR TITLE
[NS-615] Switch Redshift unloads to S3 use Role based authentication.…

### DIFF
--- a/nessie/externals/s3.py
+++ b/nessie/externals/s3.py
@@ -81,7 +81,7 @@ def get_sts_credentials():
     assumed_role_object = sts_client.assume_role(
         RoleArn=role_arn,
         RoleSessionName='AssumeAppRoleSession',
-        DurationSeconds=1800,
+        DurationSeconds=900,
     )
     return assumed_role_object['Credentials']
 

--- a/nessie/jobs/create_calnet_schema.py
+++ b/nessie/jobs/create_calnet_schema.py
@@ -44,8 +44,6 @@ class CreateCalNetSchema(BackgroundJob):
         ])
         resolved_ddl = resolve_sql_template(
             'create_calnet_schema.template.sql',
-            aws_access_key_id=app.config['AWS_ACCESS_KEY_ID'],
-            aws_secret_access_key=app.config['AWS_SECRET_ACCESS_KEY'],
             sid_snapshot_path=sid_snapshot_path,
         )
 

--- a/nessie/jobs/generate_boac_analytics.py
+++ b/nessie/jobs/generate_boac_analytics.py
@@ -44,8 +44,6 @@ class GenerateBoacAnalytics(BackgroundJob):
         boac_snapshot_daily_path = f'{self.s3_boa_path}/term/{term_id_series[0]}/daily/{hashed_datestamp()}'
         resolved_ddl = resolve_sql_template(
             'create_boac_schema.template.sql',
-            aws_access_key_id=app.config['AWS_ACCESS_KEY_ID'],
-            aws_secret_access_key=app.config['AWS_SECRET_ACCESS_KEY'],
             boac_snapshot_daily_path=boac_snapshot_daily_path,
             current_term_id=term_id_series[0],
             last_term_id=term_id_series[1],
@@ -61,8 +59,6 @@ class GenerateBoacAnalytics(BackgroundJob):
             term_name = term_name_for_sis_id(term_id)
             resolved_ddl = resolve_sql_template(
                 'unload_assignment_submissions.template.sql',
-                aws_access_key_id=app.config['AWS_ACCESS_KEY_ID'],
-                aws_secret_access_key=app.config['AWS_SECRET_ACCESS_KEY'],
                 boac_assignments_path=boac_assignments_path,
                 term_id=term_id,
                 term_name=term_name,

--- a/nessie/jobs/import_lrs_incrementals.py
+++ b/nessie/jobs/import_lrs_incrementals.py
@@ -130,15 +130,14 @@ class ImportLrsIncrementals(BackgroundJob):
             s3_url += '/' + localize_datetime(datetime.now()).strftime('%Y/%m/%d/statements_%Y%m%d_%H%M%S_')
         else:
             s3_url += '/statements'
-        credentials = ';'.join([
-            f"aws_access_key_id={app.config['AWS_ACCESS_KEY_ID']}",
-            f"aws_secret_access_key={app.config['AWS_SECRET_ACCESS_KEY']}",
-        ])
+
+        redshift_iam_role = app.config['REDSHIFT_IAM_ROLE']
         if not redshift.execute(
             f"""
                 UNLOAD ('SELECT statement FROM {schema}.statements')
                 TO '{s3_url}'
-                CREDENTIALS '{credentials}'
+                IAM_ROLE '{redshift_iam_role}'
+                ENCRYPTED
                 DELIMITER AS '  '
                 NULL AS ''
                 ALLOWOVERWRITE

--- a/nessie/sql_templates/create_boac_schema.template.sql
+++ b/nessie/sql_templates/create_boac_schema.template.sql
@@ -316,8 +316,8 @@ UNLOAD (
     GROUP BY ce.uid, ce.canvas_user_id, ce.course_id, ce.sis_enrollment_status, ce.last_activity_at, ce.current_score, ce.final_score'
 )
 TO '{boac_snapshot_daily_path}/course_scores/snapshot'
-ACCESS_KEY_ID '{aws_access_key_id}'
-SECRET_ACCESS_KEY '{aws_secret_access_key}'
+IAM_ROLE '{redshift_iam_role}'
+ENCRYPTED
 DELIMITER AS '\t'
 NULL AS ''
 ALLOWOVERWRITE
@@ -335,8 +335,8 @@ UNLOAD (
         ass.due_at, ass.submitted_at, ass.score, ass.points_possible'
 )
 TO '{boac_snapshot_daily_path}/assignment_submissions_scores/snapshot'
-ACCESS_KEY_ID '{aws_access_key_id}'
-SECRET_ACCESS_KEY '{aws_secret_access_key}'
+IAM_ROLE '{redshift_iam_role}'
+ENCRYPTED
 DELIMITER AS '\t'
 NULL AS ''
 ALLOWOVERWRITE

--- a/nessie/sql_templates/create_calnet_schema.template.sql
+++ b/nessie/sql_templates/create_calnet_schema.template.sql
@@ -57,8 +57,8 @@ UNLOAD (
     FROM {redshift_schema_calnet}.persons'
 )
 TO '{sid_snapshot_path}/snapshot'
-ACCESS_KEY_ID '{aws_access_key_id}'
-SECRET_ACCESS_KEY '{aws_secret_access_key}'
+IAM_ROLE '{redshift_iam_role}'
+ENCRYPTED
 NULL AS ''
 DELIMITER AS '\t'
 PARALLEL OFF

--- a/nessie/sql_templates/unload_assignment_submissions.template.sql
+++ b/nessie/sql_templates/unload_assignment_submissions.template.sql
@@ -50,8 +50,8 @@ UNLOAD (
     ORDER BY reference_user_id, ac1.course_id, ac2.canvas_user_id'
 )
 TO '{boac_assignments_path}/{term_id}/sub_'
-ACCESS_KEY_ID '{aws_access_key_id}'
-SECRET_ACCESS_KEY '{aws_secret_access_key}'
+IAM_ROLE '{redshift_iam_role}'
+ENCRYPTED
 DELIMITER AS ','
 NULL AS ''
 ALLOWOVERWRITE


### PR DESCRIPTION
Commit contains code to
- Switch to role-based authentication for Redshift S3 unloads
- Pass Encryption keys to use for S3 uploads explicitly. Default is AES256 set up for the account 
- Parameter KMS_KEY_ID <kms-key-id> parameter can be used for Redshift S3 unloads 

https://jira.ets.berkeley.edu/jira/browse/NS-615