### PR TITLE
NS-637 Fall back to V1 SIS Students API

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -230,6 +230,7 @@ STUDENT_API_ID = 'secretid'
 STUDENT_API_KEY = 'secretkey'
 STUDENT_API_URL = 'https://secreturl.berkeley.edu/sis/v2/students'
 STUDENT_V1_API_URL = 'https://secreturl.berkeley.edu/sis/v1/students'
+STUDENT_V1_API_PREFERRED = True
 STUDENT_API_MAX_THREADS = 5
 # Although production API hosts use app_id/app_key headers, non-production environments may use basic auth.
 STUDENT_API_PWD = None

--- a/fixtures/sis_student_api_v1_11667051.json
+++ b/fixtures/sis_student_api_v1_11667051.json
@@ -1,0 +1,932 @@
+{
+  "apiResponse": {
+    "correlationId": "b785f826-5405-432e-850c-2b6a487ab0a5",
+    "response": {
+      "any": {
+        "students": [
+          {
+            "academicStatuses": [
+              {
+                "cumulativeGPA": {
+                  "average": 0,
+                  "source": "UCB",
+                  "type": {
+                    "code": "Cumulative"
+                  }
+                },
+                "cumulativeUnits": [
+                  {
+                    "type": {
+                      "code": "Total"
+                    },
+                    "unitsCumulative": 0,
+                    "unitsEnrolled": 4,
+                    "unitsIncomplete": 0,
+                    "unitsOther": 0,
+                    "unitsPassed": 0,
+                    "unitsTaken": 0,
+                    "unitsTest": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsWaitlisted": 0
+                  },
+                  {
+                    "type": {
+                      "code": "For GPA"
+                    },
+                    "unitsEnrolled": 4,
+                    "unitsIncomplete": 0,
+                    "unitsPassed": 0,
+                    "unitsTaken": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsWaitlisted": 0
+                  },
+                  {
+                    "type": {
+                      "code": "Not For GPA"
+                    },
+                    "unitsEnrolled": 0,
+                    "unitsIncomplete": 0,
+                    "unitsPassed": 0,
+                    "unitsTaken": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsWaitlisted": 0
+                  }
+                ],
+                "currentRegistration": {
+                  "academicCareer": {
+                    "code": "UCBX",
+                    "description": "UC Berkeley Extension"
+                  },
+                  "academicLevel": {
+                    "level": {
+                      "code": "00",
+                      "description": "Not Set"
+                    },
+                    "type": {
+                      "code": "Begining of Term"
+                    }
+                  },
+                  "athlete": true,
+                  "disabled": false,
+                  "eligibleToRegister": true,
+                  "intendsToGraduate": false,
+                  "new": true,
+                  "registered": false,
+                  "specialStudyPrograms": [],
+                  "term": {
+                    "id": "2182",
+                    "name": "2018 Spring"
+                  },
+                  "termGPA": {
+                    "average": 0,
+                    "type": {
+                      "code": "Term GPA",
+                      "description": "Term GPA"
+                    }
+                  },
+                  "termUnits": [
+                    {
+                      "type": {
+                        "code": "Total",
+                        "description": "Total"
+                      },
+                      "unitsEnrolled": 4,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsOther": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTest": 0,
+                      "unitsTransferAccepted": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    },
+                    {
+                      "type": {
+                        "code": "For GPA",
+                        "description": "For GPA"
+                      },
+                      "unitsEnrolled": 4,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    },
+                    {
+                      "type": {
+                        "code": "Not For GPA",
+                        "description": "Not For GPA"
+                      },
+                      "unitsEnrolled": 0,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    }
+                  ],
+                  "withdrawalCancel": {}
+                },
+                "studentCareer": {
+                  "academicCareer": {
+                    "code": "UCBX",
+                    "description": "UCB Ext",
+                    "formalDescription": "UC Berkeley Extension",
+                    "fromDate": "2018-01-09"
+                  },
+                  "fromDate": "2018-01-09",
+                  "matriculation": {
+                    "term": {
+                      "id": "2182",
+                      "name": "2018 Spring"
+                    },
+                    "type": {
+                      "code": "NON",
+                      "description": "Non Degree/Course Work Only"
+                    }
+                  }
+                },
+                "studentPlans": [
+                  {
+                    "academicPlan": {
+                      "academicProgram": {
+                        "academicCareer": {
+                          "code": "UCBX",
+                          "description": "UCB Ext",
+                          "formalDescription": "UC Berkeley Extension",
+                          "fromDate": "2018-01-09"
+                        },
+                        "program": {
+                          "code": "XCCRT",
+                          "description": "UCBX Concurrent Enrollment"
+                        }
+                      },
+                      "cipCode": "",
+                      "hegisCode": "",
+                      "ownedBy": {
+                        "administrativeOwners": [
+                          {
+                            "organization": {
+                              "code": "UCB01",
+                              "description": "UC Berkeley"
+                            },
+                            "percentage": 100
+                          }
+                        ]
+                      },
+                      "plan": {
+                        "code": "30XCECCENX",
+                        "description": "UCBX Concurrent Enrollment",
+                        "fromDate": "2017-12-06"
+                      },
+                      "targetDegree": {},
+                      "type": {
+                        "code": "SS",
+                        "description": "Major - Self-Supporting"
+                      }
+                    },
+                    "expectedGraduationTerm": {
+                      "id": "2182",
+                      "name": "2018 Spring"
+                    },
+                    "primary": true,
+                    "statusInPlan": {
+                      "action": {
+                        "code": "MATR",
+                        "description": "Matriculation"
+                      },
+                      "reason": {
+                        "code": "NEW",
+                        "description": "New Admits"
+                      },
+                      "status": {
+                        "code": "AC",
+                        "description": "Active in Program"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "cumulativeGPA": {
+                  "average": 3.7999999999999998,
+                  "source": "UCB",
+                  "type": {
+                    "code": "Cumulative"
+                  }
+                },
+                "cumulativeUnits": [
+                  {
+                    "type": {
+                      "code": "Total"
+                    },
+                    "unitsCumulative": 101.3,
+                    "unitsOther": 0,
+                    "unitsPassed": 73,
+                    "unitsTaken": 8,
+                    "unitsTest": 3.3,
+                    "unitsTransferAccepted": 25,
+                    "unitsTransferEarned": 25
+                  },
+                  {
+                    "type": {
+                      "code": "For GPA"
+                    },
+                    "unitsPassed": 8,
+                    "unitsTaken": 8,
+                    "unitsTransferEarned": 0
+                  },
+                  {
+                    "type": {
+                      "code": "Not For GPA"
+                    },
+                    "unitsPassed": 0,
+                    "unitsTaken": 0,
+                    "unitsTransferEarned": 0
+                  }
+                ],
+                "currentRegistration": {
+                  "academicCareer": {
+                    "code": "UGRD",
+                    "description": "Undergraduate"
+                  },
+                  "academicLevel": {
+                    "level": {
+                      "code": "30",
+                      "description": "Junior"
+                    }
+                  },
+                  "athlete": true,
+                  "disabled": false,
+                  "eligibleToRegister": true,
+                  "intendsToGraduate": false,
+                  "new": false,
+                  "registered": false,
+                  "specialStudyPrograms": [],
+                  "term": {
+                    "academicYear": "2017",
+                    "id": "2172",
+                    "name": "2017 Spring"
+                  },
+                  "termGPA": {
+                    "average": 0,
+                    "type": {
+                      "description": "Term GPA"
+                    }
+                  },
+                  "termUnits": [
+                    {
+                      "type": {
+                        "description": "Total"
+                      },
+                      "unitsEnrolled": 15,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 24,
+                      "unitsMin": 15,
+                      "unitsOther": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTest": 0,
+                      "unitsTransferAccepted": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    },
+                    {
+                      "type": {
+                        "description": "For GPA"
+                      },
+                      "unitsEnrolled": 11,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    },
+                    {
+                      "type": {
+                        "description": "Not For GPA"
+                      },
+                      "unitsEnrolled": 4,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    }
+                  ]
+                },
+                "studentCareer": {
+                  "academicCareer": {
+                    "code": "UGRD",
+                    "description": "Undergraduate"
+                  },
+                  "fromDate": "2016-01-12",
+                  "matriculation": {
+                    "homeLocation": {
+                      "code": "019",
+                      "description": "Los Angeles County"
+                    },
+                    "term": {
+                      "id": "2155",
+                      "name": "2015 Summer"
+                    },
+                    "type": {
+                      "code": "",
+                      "description": ""
+                    }
+                  }
+                },
+                "studentPlans": [
+                  {
+                    "academicPlan": {
+                      "academicProgram": {
+                        "program": {
+                          "code": "UCLS",
+                          "description": "Undergrad Letters & Science"
+                        }
+                      },
+                      "plan": {
+                        "code": "25345U",
+                        "description": "English BA",
+                        "fromDate": "2016-01-12"
+                      },
+                      "targetDegree": {
+                        "type": {
+                          "code": "AB",
+                          "description": "Bachelor of Arts"
+                        }
+                      },
+                      "type": {
+                        "code": "MAJ",
+                        "description": "Major - Regular Acad/Prfnl"
+                      }
+                    },
+                    "expectedGraduationTerm": {
+                      "id": "2198",
+                      "name": "2019 Fall"
+                    },
+                    "primary": true,
+                    "statusInPlan": {
+                      "action": {
+                        "code": "DATA",
+                        "description": "Data Change"
+                      },
+                      "reason": {
+                        "code": "GTOI",
+                        "description": "Grad Term - Auto Opt-In"
+                      },
+                      "status": {
+                        "code": "AC",
+                        "description": "Active in Program"
+                      }
+                    }
+                  },
+                  {
+                    "academicPlan": {
+                      "academicProgram": {
+                        "program": {
+                          "code": "UCLS",
+                          "description": "Undergrad Letters & Science"
+                        }
+                      },
+                      "plan": {
+                        "code": "25345U",
+                        "description": "Astrophysics BS",
+                        "fromDate": "2016-01-12"
+                      },
+                      "targetDegree": {
+                        "type": {
+                          "code": "SB",
+                          "description": "Bachelor of Science"
+                        }
+                      },
+                      "type": {
+                        "code": "SP",
+                        "description": "Major - UG Specialization"
+                      }
+                    },
+                    "expectedGraduationTerm": {
+                      "id": "2192",
+                      "name": "2019 Spring"
+                    },
+                    "primary": false,
+                    "statusInPlan": {
+                      "action": {
+                        "code": "DATA",
+                        "description": "Data Change"
+                      },
+                      "reason": {
+                        "code": "GTOI",
+                        "description": "Grad Term - Auto Opt-In"
+                      },
+                      "status": {
+                        "code": "AC",
+                        "description": "Active in Program"
+                      }
+                    }
+                  },
+                  {
+                    "academicPlan": {
+                      "academicProgram": {
+                        "program": {
+                          "code": "UCLS",
+                          "description": "Undergrad Letters & Science"
+                        }
+                      },
+                      "plan": {
+                        "description": "Art History",
+                        "fromDate": "2016-01-12"
+                      },
+                      "type": {
+                        "code": "MIN"
+                      }
+                    }
+                  }
+                ],
+                "termsInAttendance": 5
+              }
+            ],
+            "addresses": [
+              {
+                "type": {
+                  "code": "HOME",
+                  "description": "Home"
+                },
+                "address1": "2121 BANCROFT WAY  #550",
+                "address2": "",
+                "address3": "",
+                "address4": "",
+                "num1": "",
+                "num2": "",
+                "addrField1": "",
+                "addrField2": "",
+                "addrField3": "",
+                "houseType": "",
+                "city": "BERKELEY",
+                "county": "",
+                "stateCode": "CA",
+                "postalCode": "454554",
+                "countryCode": "USA",
+                "formattedAddress": "2121 BANCROFT WAY  #550\nBERKELEY, CA 454554",
+                "disclose": false,
+                "uiControl": {
+                  "code": "U",
+                  "description": "Edit - No Delete"
+                },
+                "fromDate": "2015-10-07"
+              },
+              {
+                "type": {
+                  "code": "LOCL",
+                  "description": "Local"
+                },
+                "address1": "1001 Hearst",
+                "address2": "",
+                "address3": "",
+                "address4": "",
+                "num1": "",
+                "num2": "",
+                "addrField1": "",
+                "addrField2": "",
+                "addrField3": "",
+                "houseType": "",
+                "city": "Berkeley",
+                "county": "",
+                "stateCode": "CA",
+                "postalCode": "0",
+                "countryCode": "USA",
+                "formattedAddress": "1001 Hearst\nBerkeley, CA",
+                "disclose": false,
+                "uiControl": {
+                  "code": "F",
+                  "description": "Full Edit"
+                },
+                "fromDate": "2015-10-12"
+              }
+            ],
+            "affiliations": [
+              {
+                "detail": "Admitted",
+                "fromDate": "2015-12-07",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "ADMT_UX",
+                  "description": "Admitted student's access to Cal Central"
+                }
+              },
+              {
+                "detail": "",
+                "fromDate": "2015-12-14",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "STUDENT",
+                  "description": ""
+                }
+              },
+              {
+                "detail": "Active",
+                "fromDate": "2015-12-14",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "UNDERGRAD",
+                  "description": "Undergraduate Student"
+                }
+              }
+            ],
+            "awardHonors": [],
+            "birth": {
+              "date": "1975-02-05",
+              "description": "United States",
+              "locality": "YOSEMITE,CA",
+              "stateCode": "",
+              "countryCode": "USA"
+            },
+            "confidential": false,
+            "degrees": [],
+            "emails": [
+              {
+                "type": {
+                  "code": "CAMP",
+                  "description": "Campus"
+                },
+                "emailAddress": "oski@berkeley.edu",
+                "primary": true,
+                "disclose": false,
+                "uiControl": {
+                  "code": "D",
+                  "description": "Display Only"
+                }
+              }
+            ],
+            "emergencyContacts": [],
+            "ethnicities": [
+              {
+                "group": {
+                  "code": "2",
+                  "description": "Black/African American"
+                },
+                "hispanicLatino": false,
+                "detail": {
+                  "code": "BLACK",
+                  "description": "African American/Black"
+                }
+              }
+            ],
+            "gender": {
+              "discloseGenderIdentity": false,
+              "discloseGenderOfRecord": true,
+              "discloseSexAtBirth": false,
+              "fromDate": "2015-01-05",
+              "genderOfRecord": {
+                "code": "M",
+                "description": "Male"
+              }
+            },
+            "holds": [],
+            "identifiers": [
+              {
+                "disclose": false,
+                "id": "11667051",
+                "type": "student-id"
+              },
+              {
+                "disclose": false,
+                "id": "61889",
+                "type": "campus-uid"
+              },
+              {
+                "disclose": false,
+                "id": "***-**-****",
+                "type": "Social Security Number"
+              },
+              {
+                "disclose": false,
+                "fromDate": "1902-02-01",
+                "id": "11667051",
+                "type": "DB2"
+              }
+            ],
+            "languages": [
+              {
+                "code": "LGE",
+                "name": "German",
+                "native": false,
+                "teach": false,
+                "translate": false
+              }
+            ],
+            "names": [
+              {
+                "disclose": false,
+                "familyName": "Bear",
+                "formattedName": "Osk  Bear",
+                "fromDate": "2015-10-02",
+                "givenName": "Osk",
+                "middleName": "",
+                "preferred": true,
+                "prefixName": "",
+                "suffixName": "",
+                "type": {
+                  "code": "PRF",
+                  "description": "Preferred"
+                },
+                "uiControl": {
+                  "code": "U",
+                  "description": "Edit - No Delete"
+                }
+              },
+              {
+                "disclose": false,
+                "familyName": "Bear",
+                "formattedName": "Oski  Bear",
+                "fromDate": "1902-02-01",
+                "givenName": "Oski",
+                "middleName": "",
+                "preferred": false,
+                "prefixName": "",
+                "suffixName": "",
+                "type": {
+                  "code": "PRI",
+                  "description": "Primary"
+                },
+                "uiControl": {
+                  "code": "D",
+                  "description": "Display Only"
+                }
+              }
+            ],
+            "phones": [
+              {
+                "countryCode": "",
+                "disclose": false,
+                "extension": "123",
+                "number": "415/123-4567",
+                "primary": false,
+                "type": {
+                  "code": "CELL",
+                  "description": "Mobile"
+                },
+                "uiControl": {
+                  "code": "D",
+                  "description": "Display Only"
+                }
+              },
+              {
+                "countryCode": "",
+                "disclose": false,
+                "extension": "114",
+                "number": "510/642-9505",
+                "primary": true,
+                "type": {
+                  "code": "HOME",
+                  "description": "Home/Permanent"
+                },
+                "uiControl": {
+                  "code": "U",
+                  "description": "Edit - No Delete"
+                }
+              }
+            ],
+            "residency": {
+              "source": {
+                "code": "Official"
+              },
+              "fromTerm": {
+                "id": "2145",
+                "name": "2014 Summer"
+              },
+              "fromDate": "2014-05-27",
+              "financialAid": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "official": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "tuition": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "statementOfLegalResidenceStatus": {
+                "code": "D",
+                "description": "Auto Residency Determined"
+              },
+              "county": "",
+              "stateCode": "",
+              "countryCode": "USA",
+              "postalCode": "",
+              "comments": ""
+            },
+            "studentAttributes": [
+              {
+                "comments": "",
+                "fromDate": "2017-07-13",
+                "reason": {},
+                "type": {
+                  "code": "AWDP",
+                  "description": "SIR Deposit Waiver"
+                }
+              },
+              {
+                "comments": "",
+                "fromDate": "2017-07-22",
+                "reason": {},
+                "type": {
+                  "code": "R5TA",
+                  "description": "5 Terms in Attendance"
+                }
+              },
+              {
+                "type": {
+                  "code": "AHI1",
+                  "description": "Amer Hist & Inst High School"
+                },
+                "reason": {},
+                "fromDate": "2017-02-15",
+                "comments": ""
+              },
+              {
+                "type": {
+                  "code": "ELW",
+                  "description": "ELW Satisfied Pre-Matric"
+                },
+                "reason": {},
+                "fromDate": "2017-05-08",
+                "comments": ""
+              },
+              {
+                "type": {
+                  "code": "VLFL",
+                  "description": "Foreign Language - LS1"
+                },
+                "reason": {},
+                "fromDate": "2017-02-15",
+                "comments": ""
+              },
+              {
+                "type": {
+                  "code": "VAC",
+                  "description": "American Cultures"
+                },
+                "reason": {},
+                "fromDate": "2017-07-01",
+                "comments": ""
+              },
+              {
+                "comments": "",
+                "fromDate": "2017-08-08",
+                "reason": {},
+                "type": {
+                  "code": "RZA",
+                  "description": "Active Athlete"
+                }
+              },
+              {
+                "comments": "FARVW",
+                "fromDate": "2017-08-16",
+                "fromTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "reason": {
+                  "code": "FARVW",
+                  "description": "Exception from CNP",
+                  "formalDescription": "You have an exception from Cancellation for Non Payment (CNP) for this term. You will not be dropped from your classes for this term. You remain financially responsible for all charges on your Student Account. Please monitor your communications and tasks in CalCentral for updates."
+                },
+                "toTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "type": {
+                  "code": "+R99",
+                  "description": "CNP Exception"
+                }
+              },
+              {
+                "comments": "REG",
+                "fromDate": "2017-08-16",
+                "fromTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "reason": {
+                  "code": "REG",
+                  "description": "Officially Registered",
+                  "formalDescription": "You are officially registered for this term and may access campus services."
+                },
+                "toTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "type": {
+                  "code": "+REG",
+                  "description": "Officially Registered"
+                }
+              },
+              {
+                "comments": "TCALC",
+                "fromDate": "2017-08-07",
+                "fromTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "reason": {
+                  "code": "TCALC",
+                  "description": "Tuition Calculated for term",
+                  "formalDescription": "Tuition and fees have been calculated for the term."
+                },
+                "toTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "type": {
+                  "code": "+S09",
+                  "description": "Tuition Calculated"
+                }
+              }
+            ],
+            "urls": [],
+            "usaCountry": {
+              "citizenshipStatus": {
+                "code": "1",
+                "description": "Native"
+              },
+              "militaryStatus": {
+                "code": "",
+                "description": "",
+                "fromDate": "1902-02-01"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "responseType": "http://bmeta.berkeley.edu/student/studentV0.xsd/students",
+    "source": "UCB-SIS-STUDENT"
+  }
+}

--- a/fixtures/sis_student_api_v1_1234567890.json
+++ b/fixtures/sis_student_api_v1_1234567890.json
@@ -1,0 +1,864 @@
+{
+  "apiResponse": {
+    "correlationId": "b785f826-5405-432e-850c-2b6a487ab0a5",
+    "response": {
+      "any": {
+        "students": [
+          {
+            "academicStatuses": [
+              {
+                "studentCareer": {
+                  "academicCareer": {
+                    "code": "UCBX",
+                    "description": "UCB Ext",
+                    "formalDescription": "UC Berkeley Extension",
+                    "fromDate": "2018-08-15"
+                  },
+                  "fromDate": "2018-08-15"
+                },
+                "studentPlans": [
+                  {
+                    "academicPlan": {
+                      "plan": {
+                        "code": "30XCECCENX",
+                        "description": "UCBX Concurrent Enrollment",
+                        "fromDate": "2018-12-15"
+                      },
+                      "type": {
+                        "code": "SS",
+                        "description": "Major - Self-Supporting"
+                      },
+                      "cipCode": "",
+                      "hegisCode": "",
+                      "targetDegree": {},
+                      "ownedBy": {
+                        "administrativeOwners": [{
+                          "organization": {
+                            "code": "UCB01",
+                            "description": "UC Berkeley"
+                          },
+                          "percentage": 100
+                        }]
+                      },
+                      "academicProgram": {
+                        "program": {
+                          "code": "XCCRT",
+                          "description": "UCBX Concurrent Enrollment"
+                        },
+                        "academicCareer": {
+                          "code": "UCBX",
+                          "description": "UCB Ext",
+                          "formalDescription": "UC Berkeley Extension",
+                          "fromDate": "2018-08-15"
+                        }
+                      }
+                    },
+                    "statusInPlan": {
+                      "status": {
+                        "code": "DC",
+                        "description": "Discontinued"
+                      },
+                      "action": {
+                        "code": "DISC",
+                        "description": "Discontinuation"
+                      },
+                      "reason": {
+                        "code": "1TRM",
+                        "description": "DISC After One Term"
+                      }
+                    },
+                    "primary": false
+                  }
+                ],
+                "cumulativeGPA": {
+                  "type": {
+                    "code": "Cumulative"
+                  },
+                  "average": 2.646,
+                  "source": "UCB"
+                },
+                "cumulativeUnits": [
+                  {
+                    "type": {
+                      "code": "Total"
+                    },
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 13,
+                    "unitsPassed": 13,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTest": 0,
+                    "unitsOther": 0,
+                    "unitsCumulative": 13
+                  }, {
+                    "type": {
+                      "code": "For GPA"
+                    },
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 13,
+                    "unitsPassed": 13,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsTransferAccepted": 0
+                  }, {
+                    "type": {
+                      "code": "Not For GPA"
+                    },
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 0,
+                    "unitsPassed": 0,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsTransferAccepted": 0
+                  }
+                ],
+                "currentRegistration": {
+                  "term": {
+                    "id": "2188",
+                    "name": "2018 Fall"
+                  },
+                  "academicCareer": {
+                    "code": "UCBX",
+                    "description": "UC Berkeley Extension"
+                  },
+                  "eligibleToRegister": true,
+                  "eligibilityStatus": {
+                    "code": "C",
+                    "description": "Continuing"
+                  },
+                  "registered": true,
+                  "disabled": false,
+                  "athlete": false,
+                  "intendsToGraduate": false,
+                  "academicLevel": {
+                    "type": {
+                      "code": "Begining of Term"
+                    },
+                    "level": {
+                      "code": "00",
+                      "description": "Not Set"
+                    }
+                  },
+                  "termUnits": [{
+                    "type": {
+                      "code": "Total",
+                      "description": "Total"
+                    },
+                    "unitsMin": 0,
+                    "unitsMax": 0,
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 10,
+                    "unitsPassed": 10,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTest": 0,
+                    "unitsOther": 0
+                  }, {
+                    "type": {
+                      "code": "For GPA",
+                      "description": "For GPA"
+                    },
+                    "unitsMin": 0,
+                    "unitsMax": 0,
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 10,
+                    "unitsPassed": 10,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0
+                  }, {
+                    "type": {
+                      "code": "Not For GPA",
+                      "description": "Not For GPA"
+                    },
+                    "unitsMin": 0,
+                    "unitsMax": 0,
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 0,
+                    "unitsPassed": 0,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0
+                  }],
+                  "termGPA": {
+                    "type": {
+                      "code": "Term GPA",
+                      "description": "Term GPA"
+                    },
+                    "average": 2.33
+                  },
+                  "specialStudyPrograms": [],
+                  "withdrawalCancel": {},
+                  "new": true
+                }
+              },
+              {
+                "studentCareer": {
+                  "academicCareer": {
+                    "code": "UCBX",
+                    "description": "UCB Ext",
+                    "formalDescription": "UC Berkeley Extension",
+                    "fromDate": "2018-08-15"
+                  },
+                  "fromDate": "2018-08-15"
+                },
+                "studentPlans": [
+                  {
+                    "academicPlan": {
+                      "plan": {
+                        "code": "30XCECCENX",
+                        "description": "UCBX Concurrent Enrollment",
+                        "fromDate": "2018-12-15"
+                      },
+                      "type": {
+                        "code": "SS",
+                        "description": "Major - Self-Supporting"
+                      },
+                      "cipCode": "",
+                      "hegisCode": "",
+                      "targetDegree": {},
+                      "ownedBy": {
+                        "administrativeOwners": [{
+                          "organization": {
+                            "code": "UCB01",
+                            "description": "UC Berkeley"
+                          },
+                          "percentage": 100
+                        }]
+                      },
+                      "academicProgram": {
+                        "program": {
+                          "code": "XCCRT",
+                          "description": "UCBX Concurrent Enrollment"
+                        },
+                        "academicCareer": {
+                          "code": "UCBX",
+                          "description": "UCB Ext",
+                          "formalDescription": "UC Berkeley Extension",
+                          "fromDate": "2018-08-15"
+                        }
+                      }
+                    },
+                    "statusInPlan": {
+                      "action": {
+                        "code": "DATA",
+                        "description": "Data Change"
+                      },
+                      "reason": {
+                        "code": "GTOI",
+                        "description": "Grad Term - Auto Opt-In"
+                      },
+                      "status": {
+                        "code": "AC",
+                        "description": "Active in Program"
+                      }
+                    },
+                    "primary": false
+                  }
+                ],
+                "cumulativeGPA": {
+                  "type": {
+                    "code": "Cumulative"
+                  },
+                  "average": 2.646,
+                  "source": "UCB"
+                },
+                "cumulativeUnits": [
+                  {
+                    "type": {
+                      "code": "Total"
+                    },
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 13,
+                    "unitsPassed": 13,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTest": 0,
+                    "unitsOther": 0,
+                    "unitsCumulative": 13
+                  }, {
+                    "type": {
+                      "code": "For GPA"
+                    },
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 13,
+                    "unitsPassed": 13,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsTransferAccepted": 0
+                  }, {
+                    "type": {
+                      "code": "Not For GPA"
+                    },
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 0,
+                    "unitsPassed": 0,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsTransferAccepted": 0
+                  }
+                ],
+                "currentRegistration": {
+                  "term": {
+                    "id": "2188",
+                    "name": "2018 Fall"
+                  },
+                  "academicCareer": {
+                    "code": "UCBX",
+                    "description": "UC Berkeley Extension"
+                  },
+                  "eligibleToRegister": true,
+                  "eligibilityStatus": {
+                    "code": "C",
+                    "description": "Continuing"
+                  },
+                  "registered": true,
+                  "disabled": false,
+                  "athlete": false,
+                  "intendsToGraduate": false,
+                  "academicLevel": {
+                    "type": {
+                      "code": "Begining of Term"
+                    },
+                    "level": {
+                      "code": "00",
+                      "description": "Not Set"
+                    }
+                  },
+                  "termUnits": [{
+                    "type": {
+                      "code": "Total",
+                      "description": "Total"
+                    },
+                    "unitsMin": 0,
+                    "unitsMax": 0,
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 10,
+                    "unitsPassed": 10,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTest": 0,
+                    "unitsOther": 0
+                  }, {
+                    "type": {
+                      "code": "For GPA",
+                      "description": "For GPA"
+                    },
+                    "unitsMin": 0,
+                    "unitsMax": 0,
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 10,
+                    "unitsPassed": 10,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0
+                  }, {
+                    "type": {
+                      "code": "Not For GPA",
+                      "description": "Not For GPA"
+                    },
+                    "unitsMin": 0,
+                    "unitsMax": 0,
+                    "unitsEnrolled": 0,
+                    "unitsWaitlisted": 0,
+                    "unitsTaken": 0,
+                    "unitsPassed": 0,
+                    "unitsIncomplete": 0,
+                    "unitsTransferEarned": 0
+                  }],
+                  "termGPA": {
+                    "type": {
+                      "code": "Term GPA",
+                      "description": "Term GPA"
+                    },
+                    "average": 2.33
+                  },
+                  "specialStudyPrograms": [],
+                  "withdrawalCancel": {},
+                  "new": true
+                }
+              }
+            ],
+            "addresses": [
+              {
+                "type": {
+                  "code": "HOME",
+                  "description": "Home"
+                },
+                "address1": "2121 BANCROFT WAY  #550",
+                "address2": "",
+                "address3": "",
+                "address4": "",
+                "num1": "",
+                "num2": "",
+                "addrField1": "",
+                "addrField2": "",
+                "addrField3": "",
+                "houseType": "",
+                "city": "BERKELEY",
+                "county": "",
+                "stateCode": "CA",
+                "postalCode": "454554",
+                "countryCode": "USA",
+                "formattedAddress": "2121 BANCROFT WAY  #550\nBERKELEY, CA 454554",
+                "disclose": false,
+                "uiControl": {
+                  "code": "U",
+                  "description": "Edit - No Delete"
+                },
+                "fromDate": "2015-10-07"
+              },
+              {
+                "type": {
+                  "code": "LOCL",
+                  "description": "Local"
+                },
+                "address1": "1001 Hearst",
+                "address2": "",
+                "address3": "",
+                "address4": "",
+                "num1": "",
+                "num2": "",
+                "addrField1": "",
+                "addrField2": "",
+                "addrField3": "",
+                "houseType": "",
+                "city": "Berkeley",
+                "county": "",
+                "stateCode": "CA",
+                "postalCode": "0",
+                "countryCode": "USA",
+                "formattedAddress": "1001 Hearst\nBerkeley, CA",
+                "disclose": false,
+                "uiControl": {
+                  "code": "F",
+                  "description": "Full Edit"
+                },
+                "fromDate": "2015-10-12"
+              }
+            ],
+            "affiliations": [
+              {
+                "detail": "Admitted",
+                "fromDate": "2015-12-07",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "ADMT_UX",
+                  "description": "Admitted student's access to Cal Central"
+                }
+              },
+              {
+                "detail": "",
+                "fromDate": "2015-12-14",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "STUDENT",
+                  "description": ""
+                }
+              },
+              {
+                "detail": "Active",
+                "fromDate": "2015-12-14",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "UNDERGRAD",
+                  "description": "Undergraduate Student"
+                }
+              }
+            ],
+            "awardHonors": [],
+            "birth": {
+              "date": "1975-02-05",
+              "description": "United States",
+              "locality": "YOSEMITE,CA",
+              "stateCode": "",
+              "countryCode": "USA"
+            },
+            "confidential": false,
+            "degrees": [],
+            "emails": [
+              {
+                "type": {
+                  "code": "CAMP",
+                  "description": "Campus"
+                },
+                "emailAddress": "oski@berkeley.edu",
+                "primary": true,
+                "disclose": false,
+                "uiControl": {
+                  "code": "D",
+                  "description": "Display Only"
+                }
+              }
+            ],
+            "emergencyContacts": [],
+            "ethnicities": [
+              {
+                "group": {
+                  "code": "2",
+                  "description": "Black/African American"
+                },
+                "hispanicLatino": false,
+                "detail": {
+                  "code": "BLACK",
+                  "description": "African American/Black"
+                }
+              }
+            ],
+            "gender": {
+              "discloseGenderIdentity": false,
+              "discloseGenderOfRecord": true,
+              "discloseSexAtBirth": false,
+              "fromDate": "2015-01-05",
+              "genderOfRecord": {
+                "code": "M",
+                "description": "Male"
+              }
+            },
+            "holds": [],
+            "identifiers": [
+              {
+                "disclose": false,
+                "id": "1234567890",
+                "type": "student-id"
+              },
+              {
+                "disclose": false,
+                "id": "12345",
+                "type": "campus-uid"
+              },
+              {
+                "disclose": false,
+                "id": "***-**-****",
+                "type": "Social Security Number"
+              },
+              {
+                "disclose": false,
+                "fromDate": "1902-02-01",
+                "id": "1234567890",
+                "type": "DB2"
+              }
+            ],
+            "languages": [
+              {
+                "code": "LGE",
+                "name": "German",
+                "native": false,
+                "teach": false,
+                "translate": false
+              }
+            ],
+            "names": [
+              {
+                "disclose": false,
+                "familyName": "Bear",
+                "formattedName": "Osk  Bear",
+                "fromDate": "2015-10-02",
+                "givenName": "Osk",
+                "middleName": "",
+                "preferred": true,
+                "prefixName": "",
+                "suffixName": "",
+                "type": {
+                  "code": "PRF",
+                  "description": "Preferred"
+                },
+                "uiControl": {
+                  "code": "U",
+                  "description": "Edit - No Delete"
+                }
+              },
+              {
+                "disclose": false,
+                "familyName": "Bear",
+                "formattedName": "Oski  Bear",
+                "fromDate": "1902-02-01",
+                "givenName": "Oski",
+                "middleName": "",
+                "preferred": false,
+                "prefixName": "",
+                "suffixName": "",
+                "type": {
+                  "code": "PRI",
+                  "description": "Primary"
+                },
+                "uiControl": {
+                  "code": "D",
+                  "description": "Display Only"
+                }
+              }
+            ],
+            "phones": [
+              {
+                "countryCode": "",
+                "disclose": false,
+                "extension": "123",
+                "number": "415/123-4567",
+                "primary": false,
+                "type": {
+                  "code": "CELL",
+                  "description": "Mobile"
+                },
+                "uiControl": {
+                  "code": "D",
+                  "description": "Display Only"
+                }
+              },
+              {
+                "countryCode": "",
+                "disclose": false,
+                "extension": "114",
+                "number": "510/642-9505",
+                "primary": true,
+                "type": {
+                  "code": "HOME",
+                  "description": "Home/Permanent"
+                },
+                "uiControl": {
+                  "code": "U",
+                  "description": "Edit - No Delete"
+                }
+              }
+            ],
+            "residency": {
+              "source": {
+                "code": "Official"
+              },
+              "fromTerm": {
+                "id": "2145",
+                "name": "2014 Summer"
+              },
+              "fromDate": "2014-05-27",
+              "financialAid": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "official": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "tuition": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "statementOfLegalResidenceStatus": {
+                "code": "D",
+                "description": "Auto Residency Determined"
+              },
+              "county": "",
+              "stateCode": "",
+              "countryCode": "USA",
+              "postalCode": "",
+              "comments": ""
+            },
+            "studentAttributes": [
+              {
+                "comments": "",
+                "fromDate": "2017-07-13",
+                "reason": {},
+                "type": {
+                  "code": "AWDP",
+                  "description": "SIR Deposit Waiver"
+                }
+              },
+              {
+                "comments": "",
+                "fromDate": "2017-07-22",
+                "reason": {},
+                "type": {
+                  "code": "R5TA",
+                  "description": "5 Terms in Attendance"
+                }
+              },
+              {
+                "type": {
+                  "code": "AHI1",
+                  "description": "Amer Hist & Inst High School"
+                },
+                "reason": {},
+                "fromDate": "2017-02-15",
+                "comments": ""
+              },
+              {
+                "type": {
+                  "code": "ELW",
+                  "description": "ELW Satisfied Pre-Matric"
+                },
+                "reason": {},
+                "fromDate": "2017-05-08",
+                "comments": ""
+              },
+              {
+                "type": {
+                  "code": "VLFL",
+                  "description": "Foreign Language - LS1"
+                },
+                "reason": {},
+                "fromDate": "2017-02-15",
+                "comments": ""
+              },
+              {
+                "type": {
+                  "code": "VAC",
+                  "description": "American Cultures"
+                },
+                "reason": {},
+                "fromDate": "2017-07-01",
+                "comments": ""
+              },
+              {
+                "comments": "",
+                "fromDate": "2017-08-08",
+                "reason": {},
+                "type": {
+                  "code": "RZA",
+                  "description": "Active Athlete"
+                }
+              },
+              {
+                "comments": "FARVW",
+                "fromDate": "2017-08-16",
+                "fromTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "reason": {
+                  "code": "FARVW",
+                  "description": "Exception from CNP",
+                  "formalDescription": "You have an exception from Cancellation for Non Payment (CNP) for this term. You will not be dropped from your classes for this term. You remain financially responsible for all charges on your Student Account. Please monitor your communications and tasks in CalCentral for updates."
+                },
+                "toTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "type": {
+                  "code": "+R99",
+                  "description": "CNP Exception"
+                }
+              },
+              {
+                "comments": "REG",
+                "fromDate": "2017-08-16",
+                "fromTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "reason": {
+                  "code": "REG",
+                  "description": "Officially Registered",
+                  "formalDescription": "You are officially registered for this term and may access campus services."
+                },
+                "toTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "type": {
+                  "code": "+REG",
+                  "description": "Officially Registered"
+                }
+              },
+              {
+                "comments": "TCALC",
+                "fromDate": "2017-08-07",
+                "fromTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "reason": {
+                  "code": "TCALC",
+                  "description": "Tuition Calculated for term",
+                  "formalDescription": "Tuition and fees have been calculated for the term."
+                },
+                "toTerm": {
+                  "academicYear": "2018",
+                  "beginDate": "2017-08-16",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2017-12-15",
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "type": {
+                  "code": "+S09",
+                  "description": "Tuition Calculated"
+                }
+              }
+            ],
+            "urls": [],
+            "usaCountry": {
+              "citizenshipStatus": {
+                "code": "1",
+                "description": "Native"
+              },
+              "militaryStatus": {
+                "code": "",
+                "description": "",
+                "fromDate": "1902-02-01"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "responseType": "http://bmeta.berkeley.edu/student/studentV0.xsd/students",
+    "source": "UCB-SIS-STUDENT"
+  }
+}

--- a/fixtures/sis_student_api_v1_2345678901.json
+++ b/fixtures/sis_student_api_v1_2345678901.json
@@ -1,0 +1,510 @@
+{
+  "apiResponse": {
+    "correlationId": "2b6a487a-5405-432e-850c-b785f826b0a5",
+    "response": {
+      "any": {
+        "students": [
+          {
+            "academicStatuses": [
+              {
+                "cumulativeGPA": {
+                  "average": 3.2999999999999998,
+                  "source": "UCB",
+                  "type": {
+                    "code": "Cumulative"
+                  }
+                },
+                "cumulativeUnits": [
+                  {
+                    "type": {
+                      "code": "Total"
+                    },
+                    "unitsCumulative": 98.0,
+                    "unitsOther": 0,
+                    "unitsPassed": 62,
+                    "unitsTaken": 8,
+                    "unitsTest": 3.3,
+                    "unitsTransferAccepted": 25,
+                    "unitsTransferEarned": 25
+                  },
+                  {
+                    "type": {
+                      "code": "For GPA"
+                    },
+                    "unitsPassed": 8,
+                    "unitsTaken": 8,
+                    "unitsTransferEarned": 0
+                  },
+                  {
+                    "type": {
+                      "code": "Not For GPA"
+                    },
+                    "unitsPassed": 0,
+                    "unitsTaken": 0,
+                    "unitsTransferEarned": 0
+                  }
+                ],
+                "currentRegistration": {
+                  "academicCareer": {
+                    "code": "UGRD",
+                    "description": "Undergraduate"
+                  },
+                  "academicLevel": {
+                    "level": {
+                      "code": "30",
+                      "description": "Junior"
+                    }
+                  },
+                  "athlete": true,
+                  "disabled": false,
+                  "eligibleToRegister": true,
+                  "intendsToGraduate": false,
+                  "new": false,
+                  "registered": false,
+                  "specialStudyPrograms": [],
+                  "term": {
+                    "academicYear": "2017",
+                    "id": "2172",
+                    "name": "2017 Spring"
+                  },
+                  "termGPA": {
+                    "average": 0,
+                    "type": {
+                      "description": "Term GPA"
+                    }
+                  },
+                  "termUnits": [
+                    {
+                      "type": {
+                        "description": "Total"
+                      },
+                      "unitsEnrolled": 15,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsOther": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTest": 0,
+                      "unitsTransferAccepted": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    },
+                    {
+                      "type": {
+                        "description": "For GPA"
+                      },
+                      "unitsEnrolled": 11,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    },
+                    {
+                      "type": {
+                        "description": "Not For GPA"
+                      },
+                      "unitsEnrolled": 4,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    }
+                  ],
+                  "withdrawalCancel": {
+                    "date": "2017-03-31",
+                    "lastAttendedDate": "2017-03-31",
+                    "reason": {
+                      "code": "Personal"
+                    },
+                    "type": {
+                      "code": "WDR",
+                      "description": "Withdrew"
+                    }
+                  }
+                },
+                "studentCareer": {
+                  "academicCareer": {
+                    "code": "UGRD",
+                    "description": "Undergraduate"
+                  },
+                  "fromDate": "2016-01-12",
+                  "matriculation": {
+                    "homeLocation": {
+                      "code": "019",
+                      "description": "Los Angeles County"
+                    },
+                    "term": {
+                      "id": "2155",
+                      "name": "2015 Summer"
+                    },
+                    "type": {
+                      "code": "TRN",
+                      "description": "Transfer"
+                    }
+                  }
+                },
+                "studentPlans": [
+                  {
+                    "academicPlan": {
+                      "academicProgram": {
+                        "program": {
+                          "code": "UCLS",
+                          "description": "Undergrad Letters & Science"
+                        }
+                      },
+                      "plan": {
+                        "code": "25345U",
+                        "description": "English BA",
+                        "fromDate": "2016-01-12"
+                      },
+                      "targetDegree": {
+                        "type": {
+                          "code": "AB",
+                          "description": "Bachelor of Arts"
+                        }
+                      },
+                      "type": {
+                        "code": "MAJ",
+                        "description": "Major - Regular Acad/Prfnl"
+                      }
+                    },
+                    "expectedGraduationTerm": {
+                      "id": "2198",
+                      "name": "2019 Fall"
+                    },
+                    "primary": true,
+                    "statusInPlan": {
+                      "action": {
+                        "code": "DATA",
+                        "description": "Data Change"
+                      },
+                      "reason": {
+                        "code": "GTOI",
+                        "description": "Grad Term - Auto Opt-In"
+                      },
+                      "status": {
+                        "code": "AC",
+                        "description": "Active in Program"
+                      }
+                    }
+                  },
+                  {
+                    "academicPlan": {
+                      "academicProgram": {
+                        "program": {
+                          "code": "UCLS",
+                          "description": "Undergrad Letters & Science"
+                        }
+                      },
+                      "plan": {
+                        "code": "25345U",
+                        "description": "Astrophysics BS",
+                        "fromDate": "2016-01-12"
+                      },
+                      "targetDegree": {
+                        "type": {
+                          "code": "SB",
+                          "description": "Bachelor of Science"
+                        }
+                      },
+                      "type": {
+                        "code": "SP",
+                        "description": "Major - UG Specialization"
+                      }
+                    },
+                    "expectedGraduationTerm": {
+                      "id": "2192",
+                      "name": "2019 Spring"
+                    },
+                    "primary": false,
+                    "statusInPlan": {
+                      "action": {
+                        "code": "DATA",
+                        "description": "Data Change"
+                      },
+                      "reason": {
+                        "code": "GTOI",
+                        "description": "Grad Term - Auto Opt-In"
+                      },
+                      "status": {
+                        "code": "AC",
+                        "description": "Active in Program"
+                      }
+                    }
+                  },
+                  {
+                    "academicPlan": {
+                      "academicProgram": {
+                        "program": {
+                          "code": "UCLS",
+                          "description": "Undergrad Letters & Science"
+                        }
+                      },
+                      "plan": {
+                        "description": "Art History",
+                        "fromDate": "2016-01-12"
+                      },
+                      "type": {
+                        "code": "MIN"
+                      }
+                    }
+                  }
+                ],
+                "termsInAttendance": 5
+              }
+            ],
+            "addresses": [],
+            "affiliations": [
+              {
+                "detail": "Admitted",
+                "fromDate": "2015-12-07",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "ADMT_UX",
+                  "description": "Admitted student's access to Cal Central"
+                }
+              },
+              {
+                "detail": "",
+                "fromDate": "2015-12-14",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "STUDENT",
+                  "description": ""
+                }
+              },
+              {
+                "detail": "Active",
+                "fromDate": "2015-12-14",
+                "status": {
+                  "code": "ACT",
+                  "description": "Active"
+                },
+                "type": {
+                  "code": "UNDERGRAD",
+                  "description": "Undergraduate Student"
+                }
+              }
+            ],
+            "awardHonors": [],
+            "birth": {
+              "date": "1975-02-05",
+              "description": "United States",
+              "locality": "San Dimas, CA",
+              "stateCode": "",
+              "countryCode": "USA"
+            },
+            "confidential": false,
+            "degrees": [],
+            "emails": [],
+            "emergencyContacts": [],
+            "ethnicities": [],
+            "gender": {
+              "discloseGenderIdentity": false,
+              "discloseGenderOfRecord": true,
+              "discloseSexAtBirth": false,
+              "fromDate": "2015-01-05",
+              "genderOfRecord": {
+                "code": "M",
+                "description": "Male"
+              }
+            },
+            "holds": [
+              {
+                "amountRequired": 0,
+                "comments": "",
+                "contact": {
+                  "code": "",
+                  "description": ""
+                },
+                "department": {
+                  "code": "UCBKL",
+                  "description": "Department"
+                },
+                "fromDate": "2018-07-18",
+                "impacts": [
+                  {
+                    "code": "TRAN",
+                    "description": "Transcript Hold"
+                  }
+                ],
+                "reason": {
+                  "code": "CSBAL",
+                  "description": "Past due balance",
+                  "formalDescription": "Your student account has a past due balance. A hold is now placed against official registration for next semester. A hold prevents release of your transcript or diploma. Other campus services may also be withheld.\n\nUse the My Finances tab to make an online payment. \n\nFor billing questions, contact Cal Student Central at 510-664-9181 or open a case at https://studentcentral.berkeley.edu."
+                },
+                "reference": "",
+                "type": {
+                  "code": "S01",
+                  "description": "Past Due Balance"
+                }
+              },
+              {
+                "amountRequired": 0,
+                "comments": "",
+                "contact": {
+                  "code": "",
+                  "description": ""
+                },
+                "department": {
+                  "code": "UCBKL",
+                  "description": "Department"
+                },
+                "fromTerm": {
+                  "academicYear": "2019",
+                  "beginDate": "2018-08-15",
+                  "category": {
+                    "code": "R",
+                    "description": "Regular Term"
+                  },
+                  "endDate": "2018-12-14",
+                  "id": "2188",
+                  "name": "2018 Fall"
+                },
+                "impacts": [
+                  {
+                    "code": "AENR",
+                    "description": "Allow Drops, No Adds"
+                  },
+                  {
+                    "code": "IENR",
+                    "description": "No Initial Enroll, Add/Drop OK"
+                  }
+                ],
+                "reason": {
+                  "code": "ADVHD",
+                  "description": "Advisor Hold",
+                  "formalDescription": "You must see your College advisor immediately."
+                },
+                "reference": "",
+                "type": {
+                  "code": "V00",
+                  "description": "AA - Advising Holds"
+                }
+              }
+            ],
+            "identifiers": [
+              {
+                "disclose": false,
+                "id": "2345678901",
+                "type": "student-id"
+              },
+              {
+                "disclose": false,
+                "id": "98765",
+                "type": "campus-uid"
+              },
+              {
+                "disclose": false,
+                "fromDate": "1902-02-01",
+                "id": "11667051",
+                "type": "DB2"
+              }
+            ],
+            "languages": [],
+            "names": [
+              {
+                "disclose": false,
+                "familyName": "Doolittle",
+                "formattedName": "Dave Doolittle",
+                "fromDate": "2015-10-02",
+                "givenName": "Dave",
+                "middleName": "",
+                "preferred": true,
+                "prefixName": "",
+                "suffixName": "",
+                "type": {
+                  "code": "PRF",
+                  "description": "Preferred"
+                },
+                "uiControl": {
+                  "code": "U",
+                  "description": "Edit - No Delete"
+                }
+              },
+              {
+                "disclose": false,
+                "familyName": "Doolittle",
+                "formattedName": "Dave Doolittle",
+                "fromDate": "1902-02-01",
+                "givenName": "Dave",
+                "middleName": "",
+                "preferred": false,
+                "prefixName": "",
+                "suffixName": "",
+                "type": {
+                  "code": "PRI",
+                  "description": "Primary"
+                },
+                "uiControl": {
+                  "code": "D",
+                  "description": "Display Only"
+                }
+              }
+            ],
+            "phones": [],
+            "residency": {
+              "source": {
+                "code": "Official"
+              },
+              "fromTerm": {
+                "id": "2145",
+                "name": "2014 Summer"
+              },
+              "fromDate": "2014-05-27",
+              "financialAid": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "official": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "tuition": {
+                "code": "NON",
+                "description": "Non-Resident"
+              },
+              "statementOfLegalResidenceStatus": {
+                "code": "D",
+                "description": "Auto Residency Determined"
+              },
+              "county": "",
+              "stateCode": "",
+              "countryCode": "USA",
+              "postalCode": "",
+              "comments": ""
+            },
+            "studentAttributes": [],
+            "urls": [],
+            "usaCountry": {
+              "citizenshipStatus": {
+                "code": "1",
+                "description": "Native"
+              },
+              "militaryStatus": {
+                "code": "",
+                "description": "",
+                "fromDate": "1902-02-01"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "responseType": "http://bmeta.berkeley.edu/student/studentV0.xsd/students",
+    "source": "UCB-SIS-STUDENT"
+  }
+}

--- a/fixtures/students.sql
+++ b/fixtures/students.sql
@@ -90,6 +90,12 @@ CREATE TABLE IF NOT EXISTS {redshift_schema_student}.sis_api_profiles
     feed TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.sis_api_profiles_v1
+(
+    sid VARCHAR NOT NULL,
+    feed TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS {redshift_schema_student}.student_academic_status
 (
     sid VARCHAR NOT NULL,
@@ -159,6 +165,12 @@ CREATE TABLE IF NOT EXISTS {redshift_schema_student}_staging.sis_api_degree_prog
 );
 
 CREATE TABLE IF NOT EXISTS {redshift_schema_student}_staging.sis_api_profiles
+(
+    sid VARCHAR NOT NULL,
+    feed TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}_staging.sis_api_profiles_v1
 (
     sid VARCHAR NOT NULL,
     feed TEXT NOT NULL
@@ -265,3 +277,10 @@ INSERT INTO {redshift_schema_student}.sis_api_degree_progress
 (sid, feed)
 VALUES
 ('11667051', %(sis_degree_progress_11667051)s);
+
+INSERT INTO {redshift_schema_student}.sis_api_profiles_v1
+(sid, feed)
+VALUES
+('11667051', %(sis_student_api_v1_11667051)s),
+('1234567890', %(sis_student_api_v1_1234567890)s),
+('2345678901', %(sis_student_api_v1_2345678901)s);

--- a/nessie/externals/sis_student_api.py
+++ b/nessie/externals/sis_student_api.py
@@ -53,9 +53,11 @@ def get_v2_student(sid, term_id=None, as_of=None):
         return
 
 
-def _get_v1_student(sid):
+@fixture('sis_student_api_v1_{sid}')
+def _get_v1_student(sid, mock=None):
     url = http.build_url(app.config['STUDENT_V1_API_URL'] + '/' + str(sid) + '/all')
-    return authorized_request_v1(url)
+    with mock(url):
+        return authorized_request_v1(url)
 
 
 def get_v2_by_sids_list(up_to_100_sids, term_id=None, as_of=None, with_registration=False):

--- a/nessie/jobs/generate_merged_student_feeds.py
+++ b/nessie/jobs/generate_merged_student_feeds.py
@@ -35,6 +35,7 @@ from nessie.lib.metadata import get_merged_enrollment_term_job_status, queue_mer
 from nessie.lib.queries import get_advisee_student_profile_feeds
 from nessie.lib.util import encoded_tsv_row, split_tsv_row
 from nessie.merged.sis_profile import parse_merged_sis_profile
+from nessie.merged.sis_profile_v1 import parse_merged_sis_profile_v1
 from nessie.merged.student_terms import generate_student_term_maps
 from nessie.models import student_schema
 
@@ -177,11 +178,17 @@ class GenerateMergedStudentFeeds(BackgroundJob):
         uid = feeds['ldap_uid']
         if not uid:
             return
-        sis_profile = parse_merged_sis_profile(
-            feeds.get('sis_profile_feed'),
-            feeds.get('degree_progress_feed'),
-            feeds.get('last_registration_feed'),
-        )
+        if app.config['STUDENT_V1_API_PREFERRED']:
+            sis_profile = parse_merged_sis_profile_v1(
+                feeds.get('sis_profile_feed'),
+                feeds.get('degree_progress_feed'),
+            )
+        else:
+            sis_profile = parse_merged_sis_profile(
+                feeds.get('sis_profile_feed'),
+                feeds.get('degree_progress_feed'),
+                feeds.get('last_registration_feed'),
+            )
         demographics = feeds.get('demographics_feed') and json.loads(feeds.get('demographics_feed'))
         merged_profile = {
             'sid': sid,

--- a/nessie/jobs/import_sis_student_api.py
+++ b/nessie/jobs/import_sis_student_api.py
@@ -29,7 +29,7 @@ from timeit import default_timer as timer
 
 from flask import current_app as app
 from nessie.externals import redshift, s3
-from nessie.externals.sis_student_api import get_v2_by_sids_list
+from nessie.externals.sis_student_api import get_v1_student, get_v2_by_sids_list
 from nessie.jobs.background_job import BackgroundJob, BackgroundJobError
 from nessie.lib.berkeley import current_term_id
 from nessie.lib.queries import get_all_student_ids
@@ -48,12 +48,24 @@ def async_get_feeds(app_obj, up_to_100_sids):
     return result
 
 
+def async_get_feed_v1(app_obj, sid):
+    with app_obj.app_context():
+        feed = get_v1_student(sid)
+        result = {
+            'sid': sid,
+            'feed': feed,
+        }
+    return result
+
+
 class ImportSisStudentApi(BackgroundJob):
 
     redshift_schema = app.config['REDSHIFT_SCHEMA_STUDENT']
     max_threads = app.config['STUDENT_API_MAX_THREADS']
 
     def run(self, csids=None):
+        if app.config['STUDENT_V1_API_PREFERRED']:
+            return self.run_v1(csids)
         if not csids:
             csids = [row['sid'] for row in get_all_student_ids()]
         app.logger.info(f'Starting SIS student API import job for {len(csids)} students...')
@@ -103,4 +115,52 @@ class ImportSisStudentApi(BackgroundJob):
                     failure_count = len(remaining_sids)
                     app.logger.error(f'SIS student API import failed for SIDs {remaining_sids}.')
         app.logger.info(f'Wanted {len(all_sids)} students; got {len(rows)} in {timer() - start_loop} secs')
+        return rows, failure_count
+
+    def run_v1(self, csids=None):
+        if not csids:
+            csids = [row['sid'] for row in get_all_student_ids()]
+        app.logger.info(f'Starting SIS student API V1 import job for {len(csids)} students...')
+
+        rows, failure_count = self.load_concurrently_v1(csids)
+
+        s3_key = f'{get_s3_sis_api_daily_path()}/profiles.tsv'
+        app.logger.info(f'Will stash {len(rows)} feeds in S3: {s3_key}')
+        if not s3.upload_tsv_rows(rows, s3_key):
+            raise BackgroundJobError('Error on S3 upload: aborting job.')
+
+        app.logger.info('Will copy S3 feeds into Redshift...')
+        if not redshift.execute(f'TRUNCATE {self.redshift_schema}_staging.sis_api_profiles_v1'):
+            raise BackgroundJobError('Error truncating old staging rows: aborting job.')
+        if not redshift.copy_tsv_from_s3(f'{self.redshift_schema}_staging.sis_api_profiles_v1', s3_key):
+            raise BackgroundJobError('Error on Redshift copy: aborting job.')
+        staging_to_destination_query = resolve_sql_template_string(
+            """
+            DELETE FROM {redshift_schema_student}.sis_api_profiles_v1 WHERE sid IN
+                (SELECT sid FROM {redshift_schema_student}_staging.sis_api_profiles_v1);
+            INSERT INTO {redshift_schema_student}.sis_api_profiles_v1
+                (SELECT * FROM {redshift_schema_student}_staging.sis_api_profiles_v1);
+            TRUNCATE {redshift_schema_student}_staging.sis_api_profiles_v1;
+            """,
+        )
+        if not redshift.execute(staging_to_destination_query):
+            raise BackgroundJobError('Error on Redshift copy: aborting job.')
+
+        return f'SIS student API V1 import job completed: {len(rows)} succeeded, {failure_count} failed.'
+
+    def load_concurrently_v1(self, csids):
+        rows = []
+        failure_count = 0
+        app_obj = app._get_current_object()
+        start_loop = timer()
+        with ThreadPoolExecutor(max_workers=self.max_threads) as executor:
+            for result in executor.map(async_get_feed_v1, repeat(app_obj), csids):
+                csid = result['sid']
+                feed = result['feed']
+                if feed:
+                    rows.append(encoded_tsv_row([csid, json.dumps(feed)]))
+                else:
+                    failure_count += 1
+                    app.logger.error(f'SIS student API V1 import failed for CSID {csid}.')
+        app.logger.info(f'Wanted {len(csids)} students; got {len(rows)} in {timer() - start_loop} secs')
         return rows, failure_count

--- a/nessie/lib/queries.py
+++ b/nessie/lib/queries.py
@@ -82,6 +82,7 @@ def get_advisee_ids(csids=None):
 
 @fixture('query_advisee_student_profile_feeds.csv')
 def get_advisee_student_profile_feeds():
+    sis_api_profile_table = 'sis_api_profiles_v1' if app.config['STUDENT_V1_API_PREFERRED'] else 'sis_api_profiles'
     sql = f"""SELECT DISTINCT ldap.ldap_uid, ldap.sid, ldap.first_name, ldap.last_name,
                 us.canvas_id AS canvas_user_id, us.name AS canvas_user_name,
                 sis.feed AS sis_profile_feed,
@@ -91,7 +92,7 @@ def get_advisee_student_profile_feeds():
               FROM {calnet_schema()}.persons ldap
               LEFT JOIN {intermediate_schema()}.users us
                 ON us.uid = ldap.ldap_uid
-              LEFT JOIN {student_schema()}.sis_api_profiles sis
+              LEFT JOIN {student_schema()}.{sis_api_profile_table} sis
                 ON sis.sid = ldap.sid
               LEFT JOIN {student_schema()}.sis_api_degree_progress deg
                 ON deg.sid = ldap.sid

--- a/nessie/merged/sis_profile_v1.py
+++ b/nessie/merged/sis_profile_v1.py
@@ -1,0 +1,198 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import json
+import re
+
+from flask import current_app as app
+from nessie.lib.berkeley import degree_program_url_for_major, term_name_for_sis_id
+from nessie.lib.util import vacuum_whitespace
+
+
+def parse_merged_sis_profile_v1(sis_student_api_feed, degree_progress_api_feed):
+    sis_student_api_feed = sis_student_api_feed and json.loads(sis_student_api_feed)
+    if not sis_student_api_feed:
+        return False
+
+    sis_profile = {}
+
+    # We sometimes get malformed feed structures from the Hub, most often in the form of
+    # duplicate wrapped dictionaries (BOAC-362, NS-202, NS-203). Retrieve as much as we
+    # can, separately handling exceptions in different parts of the feed.
+    for merge_method in [
+        merge_sis_profile_academic_status,
+        merge_sis_profile_emails,
+        merge_sis_profile_names,
+        merge_sis_profile_phones,
+        merge_holds,
+    ]:
+        try:
+            merge_method(sis_student_api_feed, sis_profile)
+        except AttributeError as e:
+            app.logger.error(f'Hub Student API returned malformed response in {sis_student_api_feed}')
+            app.logger.error(e)
+
+    if sis_profile.get('academicCareer') == 'UGRD':
+        sis_profile['degreeProgress'] = degree_progress_api_feed and json.loads(degree_progress_api_feed)
+
+    return sis_profile
+
+
+def merge_holds(sis_student_api_feed, sis_profile):
+    sis_profile['holds'] = sis_student_api_feed.get('holds', [])
+
+
+def merge_sis_profile_academic_status(sis_student_api_feed, sis_profile):
+    # The Hub may return multiple academic statuses. We'll select the first status with a well-formed academic
+    # career that is not a concurrent enrollment.
+    academic_status = None
+    for status in sis_student_api_feed.get('academicStatuses', []):
+        career_code = status.get('currentRegistration', {}).get('academicCareer', {}).get('code')
+        if career_code and career_code != 'UCBX':
+            academic_status = status
+            break
+        elif career_code == 'UCBX':
+            academic_status = status
+            next
+    if not academic_status:
+        return
+
+    cumulative_units = None
+    cumulative_units_taken_for_gpa = None
+
+    for units in academic_status.get('cumulativeUnits', []):
+        code = units.get('type', {}).get('code')
+        if code == 'Total':
+            cumulative_units = units.get('unitsCumulative')
+        elif code == 'For GPA':
+            cumulative_units_taken_for_gpa = units.get('unitsTaken')
+
+    sis_profile['cumulativeUnits'] = cumulative_units
+
+    cumulative_gpa = academic_status.get('cumulativeGPA', {}).get('average')
+    if cumulative_gpa == 0 and not cumulative_units_taken_for_gpa:
+        sis_profile['cumulativeGPA'] = None
+    else:
+        sis_profile['cumulativeGPA'] = cumulative_gpa
+
+    sis_profile['level'] = academic_status.get('currentRegistration', {}).get('academicLevel', {}).get('level')
+    sis_profile['termsInAttendance'] = academic_status.get('termsInAttendance')
+    sis_profile['academicCareer'] = academic_status.get('currentRegistration', {}).get('academicCareer', {}).get('code')
+
+    for units in academic_status.get('currentRegistration', {}).get('termUnits', []):
+        if units.get('type', {}).get('description') == 'Total':
+            sis_profile['currentTerm'] = {
+                'unitsMaxOverride': units.get('unitsMax'),
+                'unitsMinOverride': units.get('unitsMin'),
+            }
+            break
+
+    merge_sis_profile_matriculation(academic_status, sis_profile)
+    merge_sis_profile_plans(academic_status, sis_profile)
+    merge_sis_profile_withdrawal_cancel(academic_status, sis_profile)
+
+
+def merge_sis_profile_emails(sis_student_api_feed, sis_profile):
+    primary_email = None
+    campus_email = None
+    for email in sis_student_api_feed.get('emails', []):
+        if email.get('primary'):
+            primary_email = email.get('emailAddress')
+            break
+        elif email.get('type', {}).get('code') == 'CAMP':
+            campus_email = email.get('emailAddress')
+    sis_profile['emailAddress'] = primary_email or campus_email
+
+
+def merge_sis_profile_matriculation(academic_status, sis_profile):
+    matriculation = academic_status.get('studentCareer', {}).get('matriculation')
+    if matriculation:
+        matriculation_term_name = matriculation.get('term', {}).get('name')
+        if matriculation_term_name and re.match('\A2\d{3} (?:Spring|Summer|Fall)\Z', matriculation_term_name):
+            # "2015 Fall" to "Fall 2015"
+            sis_profile['matriculation'] = ' '.join(reversed(matriculation_term_name.split()))
+        if matriculation.get('type', {}).get('code') == 'TRN':
+            sis_profile['transfer'] = True
+    if not sis_profile.get('transfer'):
+        sis_profile['transfer'] = False
+
+
+def merge_sis_profile_names(sis_student_api_feed, sis_profile):
+    for name in sis_student_api_feed.get('names', []):
+        code = name.get('type', {}).get('code')
+        if code == 'PRF':
+            sis_profile['preferredName'] = vacuum_whitespace(name.get('formattedName'))
+        elif code == 'PRI':
+            sis_profile['primaryName'] = vacuum_whitespace(name.get('formattedName'))
+        if 'primaryName' in sis_profile and 'preferredName' in sis_profile:
+            break
+
+
+def merge_sis_profile_phones(sis_student_api_feed, sis_profile):
+    phones_by_code = {
+        phone.get('type', {}).get('code'): phone.get('number')
+        for phone in sis_student_api_feed.get('phones', [])
+    }
+    sis_profile['phoneNumber'] = phones_by_code.get('CELL') or phones_by_code.get('LOCL') or phones_by_code.get('HOME')
+
+
+def merge_sis_profile_plans(academic_status, sis_profile):
+    sis_profile['plans'] = []
+    for student_plan in academic_status.get('studentPlans', []):
+        academic_plan = student_plan.get('academicPlan', {})
+        # SIS majors come in five flavors.
+        if academic_plan.get('type', {}).get('code') not in ['MAJ', 'SS', 'SP', 'HS', 'CRT']:
+            continue
+        plan = academic_plan.get('plan', {})
+        major = plan.get('description')
+        plan_feed = {
+            'degreeProgramUrl': degree_program_url_for_major(major),
+            'description': major,
+        }
+        # Find the latest expected graduation term from any plan.
+        expected_graduation_term = student_plan.get('expectedGraduationTerm', {}).get('id')
+        if expected_graduation_term and expected_graduation_term > sis_profile.get('expectedGraduationTerm', {}).get('id', '0'):
+            sis_profile['expectedGraduationTerm'] = {
+                'id': expected_graduation_term,
+                'name': term_name_for_sis_id(expected_graduation_term),
+            }
+        # Add program unless plan code indicates undeclared.
+        if plan.get('code') != '25000U':
+            program = student_plan.get('academicPlan', {}).get('academicProgram', {}).get('program', {})
+            plan_feed['program'] = program.get('description')
+        # Add plan unless it's a duplicate.
+        if not next((p for p in sis_profile['plans'] if p.get('description') == plan_feed.get('description')), None):
+            sis_profile['plans'].append(plan_feed)
+
+
+def merge_sis_profile_withdrawal_cancel(academic_status, sis_profile):
+    withdrawal_cancel = academic_status.get('currentRegistration', {}).get('withdrawalCancel', {})
+    if not withdrawal_cancel:
+        return
+    sis_profile['withdrawalCancel'] = {
+        'description': withdrawal_cancel.get('type', {}).get('description'),
+        'reason': withdrawal_cancel.get('reason', {}).get('code'),
+        'date': withdrawal_cancel.get('date'),
+    }

--- a/nessie/sql_templates/create_student_schema.template.sql
+++ b/nessie/sql_templates/create_student_schema.template.sql
@@ -58,6 +58,14 @@ CREATE TABLE IF NOT EXISTS {redshift_schema_student}.sis_api_profiles
 DISTKEY(sid)
 SORTKEY(sid);
 
+CREATE TABLE IF NOT EXISTS {redshift_schema_student}.sis_api_profiles_v1
+(
+    sid VARCHAR NOT NULL,
+    feed VARCHAR(max) NOT NULL
+)
+DISTKEY(sid)
+SORTKEY(sid);
+
 CREATE TABLE IF NOT EXISTS {redshift_schema_student}.student_last_registrations
 (
     sid VARCHAR NOT NULL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,9 @@ def student_tables(app):
     params = {}
     for key in [
         'sis_degree_progress_11667051',
+        'sis_student_api_v1_11667051',
+        'sis_student_api_v1_1234567890',
+        'sis_student_api_v1_2345678901',
     ]:
         with open(f'{fixture_path}/{key}.json', 'r') as f:
             feed = f.read()

--- a/tests/test_externals/test_sis_student_api.py
+++ b/tests/test_externals/test_sis_student_api.py
@@ -100,3 +100,25 @@ class TestSisStudentApi:
             assert not response
             assert response.raw_response.status_code == 500
             assert response.raw_response.json()['message']
+
+    def test_get_v1_student(self, app):
+        """Returns unwrapped data."""
+        student = student_api.get_v1_student(11667051)
+        assert len(student['academicStatuses']) == 2
+        assert student['academicStatuses'][0]['currentRegistration']['academicCareer']['code'] == 'UCBX'
+        assert student['academicStatuses'][1]['cumulativeGPA']['average'] == pytest.approx(3.8, 0.01)
+        assert student['academicStatuses'][1]['currentRegistration']['academicLevel']['level']['description'] == 'Junior'
+        assert student['academicStatuses'][1]['currentRegistration']['athlete'] is True
+        assert student['academicStatuses'][1]['currentRegistration']['termUnits'][0]['unitsMax'] == 24
+        assert student['academicStatuses'][1]['currentRegistration']['termUnits'][0]['unitsMin'] == 15
+        assert student['academicStatuses'][1]['studentPlans'][0]['academicPlan']['plan']['description'] == 'English BA'
+        assert student['academicStatuses'][1]['termsInAttendance'] == 5
+        assert student['emails'][0]['emailAddress'] == 'oski@berkeley.edu'
+
+    def test_inner_get_v1_student(self, app):
+        """Returns fixture data."""
+        oski_response = student_api._get_v1_student(11667051)
+        assert oski_response
+        assert oski_response.status_code == 200
+        students = oski_response.json()['apiResponse']['response']['any']['students']
+        assert len(students) == 1

--- a/tests/test_jobs/test_import_sis_student_api.py
+++ b/tests/test_jobs/test_import_sis_student_api.py
@@ -26,28 +26,42 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import json
 
 from nessie.externals import redshift
-from tests.util import mock_s3
+from tests.util import mock_s3, override_config
 
 
 class TestImportSisStudentApi:
 
     def test_import_sis_student_api(self, app, metadata_db, student_tables, caplog):
         from nessie.jobs.import_sis_student_api import ImportSisStudentApi
-        initial_rows = redshift.fetch('SELECT * FROM student_test.sis_api_profiles ORDER BY sid')
-        assert len(initial_rows) == 0
+        with override_config(app, 'STUDENT_V1_API_PREFERRED', False):
+            initial_rows = redshift.fetch('SELECT * FROM student_test.sis_api_profiles ORDER BY sid')
+            assert len(initial_rows) == 0
+            with mock_s3(app):
+                result = ImportSisStudentApi().run_wrapped()
+            assert result == 'SIS student API import job completed: 3 succeeded, 6 failed.'
+            rows = redshift.fetch('SELECT * FROM student_test.sis_api_profiles ORDER BY sid')
+            assert len(rows) == 3
+            assert rows[0]['sid'] == '11667051'
+            feed = json.loads(rows[0]['feed'], strict=False)
+            assert feed['names'][0]['familyName'] == 'Bear'
+            assert feed['registrations'][0]['term']['id'] == '2178'
+            assert rows[1]['sid'] == '1234567890'
+            feed = json.loads(rows[1]['feed'], strict=False)
+            # Needed to test proper sis_profile merging of last_registrations table.
+            assert not feed.get('registrations')
+            assert rows[2]['sid'] == '2345678901'
+            feed = json.loads(rows[2]['feed'], strict=False)
+            assert feed['registrations'][0]['term']['id'] == '2178'
+
+    def test_import_sis_student_api_v1(self, app, metadata_db, student_tables, caplog):
+        from nessie.jobs.import_sis_student_api import ImportSisStudentApi
         with mock_s3(app):
             result = ImportSisStudentApi().run_wrapped()
-        assert result == 'SIS student API import job completed: 3 succeeded, 6 failed.'
-        rows = redshift.fetch('SELECT * FROM student_test.sis_api_profiles ORDER BY sid')
+        assert result == 'SIS student API V1 import job completed: 3 succeeded, 6 failed.'
+        rows = redshift.fetch('SELECT * FROM student_test.sis_api_profiles_v1 ORDER BY sid')
         assert len(rows) == 3
         assert rows[0]['sid'] == '11667051'
+        assert rows[1]['sid'] == '1234567890'
+        assert rows[2]['sid'] == '2345678901'
         feed = json.loads(rows[0]['feed'], strict=False)
         assert feed['names'][0]['familyName'] == 'Bear'
-        assert feed['registrations'][0]['term']['id'] == '2178'
-        assert rows[1]['sid'] == '1234567890'
-        feed = json.loads(rows[1]['feed'], strict=False)
-        # Needed to test proper sis_profile merging of last_registrations table.
-        assert not feed.get('registrations')
-        assert rows[2]['sid'] == '2345678901'
-        feed = json.loads(rows[2]['feed'], strict=False)
-        assert feed['registrations'][0]['term']['id'] == '2178'

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -30,6 +30,14 @@ import pytest
 from tests.util import mock_s3
 
 
+@pytest.fixture
+def force_sis_profile_v2(app):
+    original = app.config['STUDENT_V1_API_PREFERRED']
+    app.config['STUDENT_V1_API_PREFERRED'] = False
+    yield
+    app.config['STUDENT_V1_API_PREFERRED'] = original
+
+
 @pytest.fixture()
 def sis_api_profiles(app, student_tables):
     from nessie.externals import redshift
@@ -64,6 +72,7 @@ def merged_profile(sid, profile_rows, degree_progress_rows, last_registration_ro
     return parse_merged_sis_profile(profile_feed, progress_feed, last_registration_feed)
 
 
+@pytest.mark.usefixtures('force_sis_profile_v2')
 class TestMergedSisProfile:
     """Test merged SIS profile."""
 

--- a/tests/test_merged/test_sis_profile_v1.py
+++ b/tests/test_merged/test_sis_profile_v1.py
@@ -1,0 +1,129 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import json
+
+from nessie.merged.sis_profile_v1 import parse_merged_sis_profile_v1
+import pytest
+
+
+@pytest.fixture()
+def sis_api_profiles(app, student_tables):
+    from nessie.externals import redshift
+    sql = f"""SELECT sid, feed FROM student_test.sis_api_profiles_v1"""
+    return redshift.fetch(sql)
+
+
+@pytest.fixture()
+def sis_api_degree_progress(app, student_tables):
+    from nessie.externals import redshift
+    sql = f"""SELECT sid, feed FROM student_test.sis_api_degree_progress"""
+    return redshift.fetch(sql)
+
+
+def merged_profile(sid, profile_rows, degree_progress_rows):
+    profile_feed = next((r['feed'] for r in profile_rows if r['sid'] == sid), None)
+    progress_feed = next((r['feed'] for r in degree_progress_rows if r['sid'] == sid), None)
+    return parse_merged_sis_profile_v1(profile_feed, progress_feed)
+
+
+class TestMergedSisProfile:
+    """Test merged SIS profile."""
+
+    def test_skips_concurrent_academic_status(self, app, sis_api_profiles, sis_api_degree_progress):
+        """Skips concurrent academic status if another academic status exists."""
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert profile['academicCareer'] == 'UGRD'
+
+    def test_falls_back_on_concurrent_academic_status(self, app, sis_api_profiles, sis_api_degree_progress):
+        """Selects concurrent academic status if no other academic status exists."""
+        profile = merged_profile('1234567890', sis_api_profiles, sis_api_degree_progress)
+        assert profile['academicCareer'] == 'UCBX'
+
+    def test_withdrawal_cancel_ignored_if_empty(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert 'withdrawalCancel' not in profile
+
+    def test_withdrawal_cancel_included_if_present(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('2345678901', sis_api_profiles, sis_api_degree_progress)
+        assert profile['withdrawalCancel']['description'] == 'Withdrew'
+        assert profile['withdrawalCancel']['reason'] == 'Personal'
+        assert profile['withdrawalCancel']['date'] == '2017-03-31'
+
+    def test_degree_progress(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert profile['degreeProgress']['reportDate'] == '2017-03-03'
+        assert len(profile['degreeProgress']['requirements']) == 4
+        assert profile['degreeProgress']['requirements'][0] == {'entryLevelWriting': {'status': 'Satisfied'}}
+
+    def test_no_holds(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert profile['holds'] == []
+
+    def test_multiple_holds(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('2345678901', sis_api_profiles, sis_api_degree_progress)
+        holds = profile['holds']
+        assert len(holds) == 2
+        assert holds[0]['reason']['code'] == 'CSBAL'
+        assert holds[1]['reason']['code'] == 'ADVHD'
+
+    def test_current_term(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert profile['currentTerm']['unitsMaxOverride'] == 24
+        assert profile['currentTerm']['unitsMinOverride'] == 15
+
+    def test_zero_gpa_when_gpa_units(self, app, sis_api_profiles, sis_api_degree_progress):
+        for row in sis_api_profiles:
+            if row['sid'] == '11667051':
+                feed = json.loads(row['feed'])
+                feed['academicStatuses'][1]['cumulativeGPA']['average'] = 0
+                row['feed'] = json.dumps(feed)
+                break
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert profile['cumulativeGPA'] == 0
+
+    def test_null_gpa_when_no_gpa_units(self, app, sis_api_profiles, sis_api_degree_progress):
+        for row in sis_api_profiles:
+            if row['sid'] == '11667051':
+                feed = json.loads(row['feed'])
+                feed['academicStatuses'][1]['cumulativeGPA']['average'] = 0
+                feed['academicStatuses'][1]['cumulativeUnits'][1]['unitsTaken'] = 0
+                row['feed'] = json.dumps(feed)
+                break
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert profile['cumulativeGPA'] is None
+
+    def test_expected_graduation_term(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert profile['expectedGraduationTerm']['id'] == '2198'
+        assert profile['expectedGraduationTerm']['name'] == 'Fall 2019'
+
+    def test_transfer_true_if_notation_present(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('2345678901', sis_api_profiles, sis_api_degree_progress)
+        assert profile['transfer'] is True
+
+    def test_transfer_false_if_notation_not_present(self, app, sis_api_profiles, sis_api_degree_progress):
+        profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
+        assert profile['transfer'] is False


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-637

Because the V2 API integration tried to keep upper-layer data feeds stable, the V1 reversion can (theoretically) be swapped back in without much disruption. As usual with this massive operation, though, the only way to test that assumption is to try it on a running system and live with any delays that result.

In other words, a close code review would be even more appreciated than usual.