### PR TITLE
BOAC-2395: Expands advising_note_authors to include ASC and E&I

### DIFF
--- a/nessie/jobs/index_advising_note_authors.py
+++ b/nessie/jobs/index_advising_note_authors.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from flask import current_app as app
-from nessie.externals import rds
+from nessie.externals import calnet, rds, redshift
 from nessie.jobs.background_job import BackgroundJob, BackgroundJobError
 from nessie.lib.util import resolve_sql_template
 
@@ -36,9 +36,64 @@ class IndexAdvisingNoteAuthors(BackgroundJob):
     def run(self):
         app.logger.info(f'Starting Advising Note author names index job...')
         app.logger.info(f'Executing SQL...')
+        self.create_advising_note_authors()
+        self.import_note_authors()
         self.index_author_names()
 
         return 'Advising Note author names index job completed.'
+
+    def create_advising_note_authors(self):
+        resolved_ddl = resolve_sql_template('create_advising_note_authors.template.sql')
+        if rds.execute(resolved_ddl):
+            app.logger.info('Created advising note authors.')
+        else:
+            raise BackgroundJobError('Failed to create advising note authors.')
+
+    def import_note_authors(self):
+        notes_schema = app.config['RDS_SCHEMA_ADVISING_NOTES']
+        asc_schema = app.config['RDS_SCHEMA_ASC']
+        e_i_schema = app.config['RDS_SCHEMA_E_I']
+        sis_notes_schema = app.config['RDS_SCHEMA_SIS_ADVISING_NOTES']
+        advisor_schema_redshift = app.config['REDSHIFT_SCHEMA_ADVISOR_INTERNAL']
+
+        advisor_sids_from_sis_notes = set(
+            [r['advisor_sid'] for r in rds.fetch(f'SELECT DISTINCT advisor_sid FROM {sis_notes_schema}.advising_notes')],
+        )
+        advisor_sids_from_advisors = set(
+            [r['sid'] for r in redshift.fetch(f'SELECT DISTINCT sid FROM {advisor_schema_redshift}.advisor_departments')],
+        )
+        advisor_sids = list(advisor_sids_from_sis_notes | advisor_sids_from_advisors)
+
+        advisor_uids_from_asc_notes = set(
+            [r['advisor_uid'] for r in rds.fetch(f'SELECT DISTINCT advisor_uid FROM {asc_schema}.advising_notes')],
+        )
+        advisor_uids_from_e_i_notes = set(
+            [r['advisor_uid'] for r in rds.fetch(f'SELECT DISTINCT advisor_uid FROM {e_i_schema}.advising_notes')],
+        )
+        advisor_uids = list(advisor_uids_from_asc_notes | advisor_uids_from_e_i_notes)
+
+        advisor_attributes = calnet.client(app).search_csids(advisor_sids) + calnet.client(app).search_uids(advisor_uids)
+        if not advisor_attributes:
+            raise BackgroundJobError('Failed to fetch note author attributes.')
+
+        unique_advisor_attributes = list({adv['uid']: adv for adv in advisor_attributes}.values())
+
+        with rds.transaction() as transaction:
+            insertable_rows = []
+            for entry in unique_advisor_attributes:
+                first_name, last_name = calnet.split_sortable_name(entry)
+                insertable_rows.append(tuple((entry.get('uid'), entry.get('csid'), first_name, last_name)))
+
+            result = transaction.insert_bulk(
+                f'INSERT INTO {notes_schema}.advising_note_authors (uid, sid, first_name, last_name) VALUES %s',
+                insertable_rows,
+            )
+            if result:
+                transaction.commit()
+                app.logger.info('Imported advising note author attributes.')
+            else:
+                transaction.rollback()
+                raise BackgroundJobError('Failed to import advising note author attributes.')
 
     def index_author_names(self):
         resolved_ddl = resolve_sql_template('index_advising_note_authors.template.sql')

--- a/nessie/sql_templates/create_advising_note_authors.template.sql
+++ b/nessie/sql_templates/create_advising_note_authors.template.sql
@@ -29,28 +29,18 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA {rds_schema_advising_notes} GRANT SELECT ON T
 
 BEGIN TRANSACTION;
 
-DROP TABLE IF EXISTS {rds_schema_advising_notes}.advising_note_author_names CASCADE;
+DROP TABLE IF EXISTS {rds_schema_advising_notes}.advising_note_authors CASCADE;
 
-CREATE TABLE {rds_schema_advising_notes}.advising_note_author_names
+CREATE TABLE {rds_schema_advising_notes}.advising_note_authors
 (
     uid VARCHAR NOT NULL,
-    name VARCHAR NOT NULL,
-    PRIMARY KEY (uid, name)
+    sid VARCHAR NOT NULL,
+    first_name VARCHAR NOT NULL,
+    last_name VARCHAR NOT NULL,
+    PRIMARY KEY (uid)
 );
 
-CREATE INDEX IF NOT EXISTS advising_note_author_names_name_idx
-ON {rds_schema_advising_notes}.advising_note_author_names (name);
-
-INSERT INTO {rds_schema_advising_notes}.advising_note_author_names (
-    SELECT DISTINCT uid, unnest(string_to_array(
-        regexp_replace(upper(first_name), '[^\w ]', '', 'g'),
-        ' '
-    )) AS name FROM {rds_schema_advising_notes}.advising_note_authors
-    UNION
-    SELECT DISTINCT uid, unnest(string_to_array(
-        regexp_replace(upper(last_name), '[^\w ]', '', 'g'),
-        ' '
-    )) AS name FROM {rds_schema_advising_notes}.advising_note_authors
-);
+CREATE INDEX IF NOT EXISTS advising_note_authors_sid_idx
+ON {rds_schema_advising_notes}.advising_note_authors (sid);
 
 COMMIT TRANSACTION;

--- a/nessie/sql_templates/index_sis_advising_notes.template.sql
+++ b/nessie/sql_templates/index_sis_advising_notes.template.sql
@@ -110,16 +110,4 @@ CREATE INDEX idx_advising_notes_ft_search
 ON {rds_schema_sis_advising_notes}.advising_notes_search_index
 USING gin(fts_index);
 
-CREATE TABLE IF NOT EXISTS {rds_schema_sis_advising_notes}.advising_note_authors
-(
-    uid VARCHAR NOT NULL,
-    sid VARCHAR NOT NULL,
-    first_name VARCHAR NOT NULL,
-    last_name VARCHAR NOT NULL,
-    PRIMARY KEY (uid)
-);
-
-CREATE INDEX IF NOT EXISTS advising_note_authors_sid_idx
-ON {rds_schema_sis_advising_notes}.advising_note_authors (sid);
-
 COMMIT TRANSACTION;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2395

This moves the advising_note_authors table from the SIS-specific schema to the general advising notes schema and adds advisors from ASC and E&I.  This will make it easier to return ASC and E&I notes in a search by author in BOA.