### PR TITLE
NS-669 Only request SIS Students API "contacts" when needed

### DIFF
--- a/nessie/externals/sis_student_api.py
+++ b/nessie/externals/sis_student_api.py
@@ -60,8 +60,8 @@ def _get_v1_student(sid, mock=None):
         return authorized_request_v1(url)
 
 
-def get_v2_by_sids_list(up_to_100_sids, term_id=None, as_of=None, with_registration=False):
-    response = _get_v2_by_sids_list(up_to_100_sids, term_id, as_of, with_registration)
+def get_v2_by_sids_list(up_to_100_sids, term_id=None, as_of=None, with_registration=False, with_contacts=True):
+    response = _get_v2_by_sids_list(up_to_100_sids, term_id, as_of, with_registration, with_contacts)
     if response and hasattr(response, 'json'):
         unwrapped = response.json().get('apiResponse', {}).get('response', {}).get('students', [])
         if len(unwrapped) < len(up_to_100_sids):
@@ -145,7 +145,7 @@ def get_sis_students_list(all_sids):
 
 
 @fixture('sis_student_list_api_v2')
-def _get_v2_by_sids_list(up_to_100_sids, term_id=None, as_of=None, with_registration=False, mock=None):
+def _get_v2_by_sids_list(up_to_100_sids, term_id, as_of, with_registration, with_contacts, mock=None):
     """Collect SIS Student Profile data for up to 100 SIDs at a time.
 
     The SIS 'list' request does not return studentAttributes, ethnicities, or gender. (In other words, 'inc-attr',
@@ -158,7 +158,7 @@ def _get_v2_by_sids_list(up_to_100_sids, term_id=None, as_of=None, with_registra
         'id-list': id_list,
         'affiliation-status': 'ALL',
         'inc-acad': True,
-        'inc-cntc': True,
+        'inc-cntc': with_contacts,
         'inc-completed-programs': True,
         'inc-inactive-programs': True,
     }

--- a/tests/test_externals/test_sis_student_api.py
+++ b/tests/test_externals/test_sis_student_api.py
@@ -58,7 +58,13 @@ class TestSisStudentApi:
 
     def test_inner_get_students(self, app):
         """Returns fixture data."""
-        oski_response = student_api._get_v2_by_sids_list(TEST_SID_LIST, term_id=current_term_id(), with_registration=True)
+        oski_response = student_api._get_v2_by_sids_list(
+            TEST_SID_LIST,
+            term_id=current_term_id(),
+            as_of=None,
+            with_registration=True,
+            with_contacts=True,
+        )
         assert oski_response
         assert oski_response.status_code == 200
         students = oski_response.json()['apiResponse']['response']['students']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-669

A very small performance boost when we can take advantage of it.