### PR TITLE
BOAC-2753, until SISRP-48560 is resolved, we treat 0.5 as 12, the expected min-units per term

### DIFF
--- a/nessie/lib/util.py
+++ b/nessie/lib/util.py
@@ -181,3 +181,10 @@ def resolve_sql_template(sql_filename, **kwargs):
     # Let's leave the preprended copyright and license text out of this.
     template_string = re.sub(r'^/\*.*?\*/\s*', '', template_string, flags=re.DOTALL)
     return resolve_sql_template_string(template_string, **kwargs)
+
+
+def to_float(s):
+    try:
+        return float(s)
+    except ValueError:
+        return None

--- a/nessie/merged/sis_profile_v1.py
+++ b/nessie/merged/sis_profile_v1.py
@@ -104,8 +104,8 @@ def merge_sis_profile_academic_status(sis_student_api_feed, sis_profile):
     for units in academic_status.get('currentRegistration', {}).get('termUnits', []):
         if units.get('type', {}).get('description') == 'Total':
             sis_profile['currentTerm'] = {
-                'unitsMaxOverride': units.get('unitsMax'),
-                'unitsMinOverride': units.get('unitsMin'),
+                'unitsMax': units.get('unitsMax'),
+                'unitsMin': units.get('unitsMin'),
             }
             break
 

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -121,8 +121,8 @@ class TestMergedSisProfile:
         assert profile['currentRegistration']['term']['id'] == '2178'
         assert profile['level']['code'] == '30'
         assert profile['level']['description'] == 'Junior'
-        assert profile['currentTerm']['unitsMaxOverride'] == 24
-        assert profile['currentTerm']['unitsMinOverride'] == 15
+        assert profile['currentTerm']['unitsMax'] == 24
+        assert profile['currentTerm']['unitsMin'] == 15
 
     def test_zero_gpa_when_gpa_units(self, app, sis_api_profiles, sis_api_degree_progress, sis_api_last_registrations):
         for row in sis_api_profiles:

--- a/tests/test_merged/test_sis_profile_v1.py
+++ b/tests/test_merged/test_sis_profile_v1.py
@@ -91,8 +91,8 @@ class TestMergedSisProfile:
 
     def test_current_term(self, app, sis_api_profiles, sis_api_degree_progress):
         profile = merged_profile('11667051', sis_api_profiles, sis_api_degree_progress)
-        assert profile['currentTerm']['unitsMaxOverride'] == 24
-        assert profile['currentTerm']['unitsMinOverride'] == 15
+        assert profile['currentTerm']['unitsMax'] == 24
+        assert profile['currentTerm']['unitsMin'] == 15
 
     def test_zero_gpa_when_gpa_units(self, app, sis_api_profiles, sis_api_degree_progress):
         for row in sis_api_profiles:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2753

I changed keys `unitsMaxOverride` and `unitsMinOverride` to  `unitsMax` and `unitsMin` because they are not necessarily "overrides" – the attributes might carry default values. If this PR is merged then I'll submit (1) a QA PR and (2) the necessary BOA PRs.