### PR TITLE
NS-696: Standardizes time zones across SIS attachment jobs

### DIFF
--- a/tests/test_jobs/test_migrate_sis_advising_note_attachments.py
+++ b/tests/test_jobs/test_migrate_sis_advising_note_attachments.py
@@ -59,12 +59,13 @@ def get_s3_refs(app):
 
 
 class TestMigrateSisAdvisingNoteAttachments:
+    """Copies files from source path(s) to the destination, organized into folders by SID."""
 
-    @mock.patch('nessie.jobs.migrate_sis_advising_note_attachments.datetime', autospec=True)
+    @mock.patch('nessie.lib.util.datetime', autospec=True)
     def test_first_time_run_with_no_param(self, mock_datetime, app, caplog, metadata_db):
-        """Copies files from all folders to destination, organized into folders by SID."""
+        """When no parameter is provided and there is no prior successful run, copies all files."""
         (bucket, source_prefix, dest_prefix) = get_s3_refs(app)
-        mock_datetime.now.return_value = datetime(year=2019, month=8, day=29)
+        mock_datetime.utcnow.return_value = datetime(year=2019, month=8, day=29, hour=5)
 
         caplog.set_level(logging.INFO)
         with capture_app_logs(app):
@@ -73,40 +74,52 @@ class TestMigrateSisAdvisingNoteAttachments:
                 m3.Object(bucket, f'{source_prefix}/2019/08/28/23456789_00003_1.png').put(Body=b'another note attachment')
                 m3.Object(bucket, f'{source_prefix}/2019/08/29/34567890_00014_2.xls').put(Body=b'ok to copy me')
 
-                MigrateSisAdvisingNoteAttachments().run()
+                response = MigrateSisAdvisingNoteAttachments().run()
 
-                assert f'Will copy files from {source_prefix}/.' in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files/.' in caplog.text
                 assert 'Copied 3 attachments to the destination folder.' in caplog.text
+                assert response == (
+                    'SIS advising note attachment migration complete for sis-data/sis-sftp/incremental/advising-notes/attachment-files/.'
+                )
                 assert object_exists(m3, bucket, f'{dest_prefix}/12345678/12345678_00012_1.pdf')
                 assert object_exists(m3, bucket, f'{dest_prefix}/23456789/23456789_00003_1.png')
                 assert object_exists(m3, bucket, f'{dest_prefix}/34567890/34567890_00014_2.xls')
 
-    @mock.patch('nessie.jobs.migrate_sis_advising_note_attachments.datetime', autospec=True)
+    @mock.patch('nessie.lib.util.datetime', autospec=True)
     def test_run_with_no_param(self, mock_datetime, app, caplog, metadata_db, prior_job_status):
-        """Copies new files since the last succesful run to destination (excluding today's date), organized into folders by SID."""
+        """When no parameter is provided, copies new files since the last succesful run."""
         (bucket, source_prefix, dest_prefix) = get_s3_refs(app)
-        mock_datetime.now.return_value = datetime(year=2019, month=8, day=29)
+        mock_datetime.utcnow.return_value = datetime(year=2019, month=8, day=29, hour=5)
 
         caplog.set_level(logging.INFO)
         with capture_app_logs(app):
             with mock_s3(app, bucket=bucket) as m3:
-                m3.Object(bucket, f'{source_prefix}/2019/08/26/45678912_00027_1.pdf').put(Body=b'i\'ve already been copied')
-                m3.Object(bucket, f'{source_prefix}/2019/08/27/12345678_00012_1.pdf').put(Body=b'a note attachment')
+                m3.Object(bucket, f'{source_prefix}/2019/08/25/45678912_00027_1.pdf').put(Body=b'i\'ve already been copied')
+                m3.Object(bucket, f'{source_prefix}/2019/08/26/12345678_00012_1.pdf').put(Body=b'a note attachment')
                 m3.Object(bucket, f'{source_prefix}/2019/08/28/23456789_00003_1.png').put(Body=b'another note attachment')
                 m3.Object(bucket, f'{source_prefix}/2019/08/29/34567890_00014_2.xls').put(Body=b'don\'t copy me')
 
-                MigrateSisAdvisingNoteAttachments().run()
+                response = MigrateSisAdvisingNoteAttachments().run()
 
-                assert f'Will copy files from {source_prefix}/2019/08/27.' in caplog.text
-                assert f'Will copy files from {source_prefix}/2019/08/28.' in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/25.' not in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/26.' in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/27.' in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/28.' in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/29.' not in caplog.text
                 assert 'Copied 1 attachments to the destination folder.' in caplog.text
+                assert 'Copied 0 attachments to the destination folder.' in caplog.text
+                assert response == (
+                    'SIS advising note attachment migration complete for sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/26, \
+sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/27, \
+sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/28.'
+                )
                 assert not object_exists(m3, bucket, f'{dest_prefix}/45678912/45678912_00027_1.xls')
                 assert object_exists(m3, bucket, f'{dest_prefix}/12345678/12345678_00012_1.pdf')
                 assert object_exists(m3, bucket, f'{dest_prefix}/23456789/23456789_00003_1.png')
                 assert not object_exists(m3, bucket, f'{dest_prefix}/34567890/34567890_00014_2.xls')
 
     def test_run_with_datestamp_param(self, app, caplog):
-        """Copies files from the specified dated folder to destination, organized into folders by SID."""
+        """When datestamp is provided, copies files from the corresponding dated folder."""
         (bucket, source_prefix, dest_prefix) = get_s3_refs(app)
         datestamp = '2019-08-28'
 
@@ -117,16 +130,19 @@ class TestMigrateSisAdvisingNoteAttachments:
                 m3.Object(bucket, f'{source_prefix}/2019/08/28/23456789_00003_1.png').put(Body=b'another note attachment')
                 m3.Object(bucket, f'{source_prefix}/2019/08/29/34567890_00014_2.xls').put(Body=b'don\'t copy me')
 
-                MigrateSisAdvisingNoteAttachments().run(datestamp=datestamp)
+                response = MigrateSisAdvisingNoteAttachments().run(datestamp=datestamp)
 
-                assert f'Will copy files from {source_prefix}/2019/08/28.' in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/28.' in caplog.text
                 assert 'Copied 2 attachments to the destination folder.' in caplog.text
+                assert response == (
+                    'SIS advising note attachment migration complete for sis-data/sis-sftp/incremental/advising-notes/attachment-files/2019/08/28.'
+                )
                 assert object_exists(m3, bucket, f'{dest_prefix}/12345678/12345678_00012_1.pdf')
                 assert object_exists(m3, bucket, f'{dest_prefix}/23456789/23456789_00003_1.png')
                 assert not object_exists(m3, bucket, f'{dest_prefix}/34567890/34567890_00014_2.xls')
 
     def test_run_with_all_param(self, app, caplog):
-        """Copies files from all folders to destination, organized into folders by SID."""
+        """When 'all' is provided, copies all files."""
         (bucket, source_prefix, dest_prefix) = get_s3_refs(app)
         datestamp = 'all'
 
@@ -137,16 +153,19 @@ class TestMigrateSisAdvisingNoteAttachments:
                 m3.Object(bucket, f'{source_prefix}/2019/08/28/23456789_00003_1.png').put(Body=b'another note attachment')
                 m3.Object(bucket, f'{source_prefix}/2019/08/29/34567890_00014_2.xls').put(Body=b'ok to copy me')
 
-                MigrateSisAdvisingNoteAttachments().run(datestamp=datestamp)
+                response = MigrateSisAdvisingNoteAttachments().run(datestamp=datestamp)
 
-                assert f'Will copy files from {source_prefix}/.' in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files.' in caplog.text
                 assert 'Copied 3 attachments to the destination folder.' in caplog.text
+                assert response == (
+                    'SIS advising note attachment migration complete for sis-data/sis-sftp/incremental/advising-notes/attachment-files.'
+                )
                 assert object_exists(m3, bucket, f'{dest_prefix}/12345678/12345678_00012_1.pdf')
                 assert object_exists(m3, bucket, f'{dest_prefix}/23456789/23456789_00003_1.png')
                 assert object_exists(m3, bucket, f'{dest_prefix}/34567890/34567890_00014_2.xls')
 
     def test_run_with_invalid_param(self, app, caplog):
-        """Job completes but copies zero files."""
+        """When invalid value is provided, job completes but copies zero files."""
         (bucket, source_prefix, dest_prefix) = get_s3_refs(app)
         datestamp = 'wrong!#$&'
 
@@ -155,8 +174,11 @@ class TestMigrateSisAdvisingNoteAttachments:
             with mock_s3(app, bucket=bucket) as m3:
                 m3.Object(bucket, f'{source_prefix}/2019/08/28/12345678_00012_1.pdf').put(Body=b'a note attachment')
 
-                MigrateSisAdvisingNoteAttachments().run(datestamp=datestamp)
+                response = MigrateSisAdvisingNoteAttachments().run(datestamp=datestamp)
 
-                assert f'Will copy files from {source_prefix}/{datestamp}.' in caplog.text
+                assert f'Will copy files from /sis-data/sis-sftp/incremental/advising-notes/attachment-files/wrong!#$&.' in caplog.text
                 assert 'Copied 0 attachments to the destination folder.' in caplog.text
+                assert response == (
+                    'SIS advising note attachment migration complete for sis-data/sis-sftp/incremental/advising-notes/attachment-files/wrong!#$&.'
+                )
                 assert not object_exists(m3, bucket, f'{dest_prefix}/12345678/12345678_00012_1.pdf')

--- a/tests/test_jobs/test_verify_sis_advising_note_attachments.py
+++ b/tests/test_jobs/test_verify_sis_advising_note_attachments.py
@@ -1,0 +1,161 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+from contextlib import contextmanager
+from datetime import datetime
+import logging
+
+import mock
+from nessie.jobs.background_job import BackgroundJobError
+from nessie.jobs.verify_sis_advising_note_attachments import VerifySisAdvisingNoteAttachments
+import pytest
+from tests.util import capture_app_logs, mock_s3
+
+
+def get_s3_refs(app):
+    bucket = app.config['LOCH_S3_PROTECTED_BUCKET']
+    source_prefix = app.config['LOCH_S3_ADVISING_NOTE_ATTACHMENT_SOURCE_PATH']
+    dest_prefix = app.config['LOCH_S3_ADVISING_NOTE_ATTACHMENT_DEST_PATH']
+    return (bucket, source_prefix, dest_prefix)
+
+
+@contextmanager
+def set_up_to_succeed(app, caplog):
+    (bucket, source_prefix, dest_prefix) = get_s3_refs(app)
+    caplog.set_level(logging.INFO)
+    with capture_app_logs(app):
+        with mock_s3(app, bucket=bucket) as m3:
+            m3.Object(bucket, f'{source_prefix}/2017/01/18/12345678_00012_1.pdf').put(Body=b'a note attachment')
+            m3.Object(bucket, f'{source_prefix}/2018/12/22/23456789_00003_1.png').put(Body=b'another note attachment')
+            m3.Object(bucket, f'{source_prefix}/2019/08/29/34567890_00014_2.xls').put(Body=b'yet another note attachment')
+            m3.Object(bucket, f'{dest_prefix}/12345678/12345678_00012_1.pdf').put(Body=b'a note attachment')
+            m3.Object(bucket, f'{dest_prefix}/23456789/23456789_00003_1.png').put(Body=b'another note attachment')
+            m3.Object(bucket, f'{dest_prefix}/34567890/34567890_00014_2.xls').put(Body=b'yet another note attachment')
+            yield
+    assert f'No attachments missing on S3 when compared against the view.' in caplog.text
+
+
+@contextmanager
+def set_up_to_fail(app, caplog):
+    (bucket, source_prefix, dest_prefix) = get_s3_refs(app)
+    caplog.set_level(logging.INFO)
+    with capture_app_logs(app):
+        with mock_s3(app, bucket=bucket) as m3:
+            m3.Object(bucket, f'{source_prefix}/2017/01/18/12345678_00012_1.pdf').put(Body=b'a note attachment')
+            m3.Object(bucket, f'{source_prefix}/2018/12/22/23456789_00003_1.png').put(Body=b'another note attachment')
+            m3.Object(bucket, f'{dest_prefix}/12345678/12345678_00012_1.pdf').put(Body=b'a note attachment')
+            m3.Object(bucket, f'{dest_prefix}/34567890/34567890_00014_2.xls').put(Body=b'yet another note attachment')
+            m3.Object(bucket, f'{dest_prefix}/45678901/45678901_00192_4.xls').put(Body=b'bamboozled by a completely unexpected note attachment')
+            with pytest.raises(BackgroundJobError) as e:
+                yield
+    assert 'Attachments verification found missing attachments or sync failures:' in str(e.value)
+    assert '\'attachment_sync_failure_count\': 1' in str(e.value)
+    assert '\'missing_s3_attachments_count\': 1' in str(e.value)
+    assert '\'attachment_sync_failures\': [\'sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22/23456789_00003_1.png\']' in str(
+        e.value,
+    )
+    assert '\'missing_s3_attachments\': [\'23456789_00003_1.png\']' in str(e.value)
+    assert 'Attachments missing on S3 when compared against SIS notes views: 1' in caplog.text
+
+
+@pytest.fixture()
+def prior_job_status(app):
+    from nessie.externals import rds
+    rds_schema = app.config['RDS_SCHEMA_METADATA']
+    rds.execute(f"""INSERT INTO {rds_schema}.background_job_status
+                (job_id, status, instance_id, created_at, updated_at)
+                VALUES ('MigrateSisAdvisingNoteAttachments_123', 'succeeded', 'abc', '2018-12-21 00:00:00', '2018-12-21 00:00:00')""")
+
+
+class TestVerifySisAdvisingNoteAttachments:
+    """Validates the work of MigrateSisAdvisingNoteAttachments and reports any failures."""
+
+    def test_run_with_no_param(self, app, caplog, sis_note_tables):
+        """When no parameter is provided, validates all files."""
+        with set_up_to_succeed(app, caplog):
+            response = VerifySisAdvisingNoteAttachments().run()
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/.' in caplog.text
+        assert 'No attachment sync failures found from sis-data/sis-sftp/incremental/advising-notes/attachment-files/.' in caplog.text
+        assert response == 'Note attachment verification completed successfully. No missing attachments or sync failures found.'
+
+        with set_up_to_fail(app, caplog):
+            response = VerifySisAdvisingNoteAttachments().run()
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/.' in caplog.text
+        assert 'Total number of failed attachment syncs from sis-data/sis-sftp/incremental/advising-notes/attachment-files/ is 1' in caplog.text
+
+    def test_run_with_all_param(self, app, caplog, sis_note_tables):
+        """When 'all' is provided, validates all files."""
+        with set_up_to_succeed(app, caplog):
+            response = VerifySisAdvisingNoteAttachments().run(datestamp='all')
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files.' in caplog.text
+        assert 'No attachment sync failures found from sis-data/sis-sftp/incremental/advising-notes/attachment-files.' in caplog.text
+        assert response == 'Note attachment verification completed successfully. No missing attachments or sync failures found.'
+
+        with set_up_to_fail(app, caplog):
+            response = VerifySisAdvisingNoteAttachments().run(datestamp='all')
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files.' in caplog.text
+        assert 'Total number of failed attachment syncs from sis-data/sis-sftp/incremental/advising-notes/attachment-files is 1' in caplog.text
+
+    @mock.patch('nessie.lib.util.datetime', autospec=True)
+    def test_run_with_last_run_param(self, mock_datetime, sis_note_tables, app, caplog, metadata_db, prior_job_status):
+        """When 'since_successful_run' is provided, validates files received since the last successful run of MigrateSisAdvisingNoteAttachments."""
+        mock_datetime.utcnow.return_value = datetime(year=2018, month=12, day=23, hour=5)
+
+        with set_up_to_succeed(app, caplog):
+            response = VerifySisAdvisingNoteAttachments().run(datestamp='since_successful_run')
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/20.' in caplog.text
+        assert 'No attachment sync failures found from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/20.' in caplog.text
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/21.' in caplog.text
+        assert 'No attachment sync failures found from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/21.' in caplog.text
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22.' in caplog.text
+        assert 'No attachment sync failures found from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22.' in caplog.text
+        assert response == 'Note attachment verification completed successfully. No missing attachments or sync failures found.'
+
+        with set_up_to_fail(app, caplog):
+            response = VerifySisAdvisingNoteAttachments().run(datestamp='since_successful_run')
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/20.' in caplog.text
+        assert 'No attachment sync failures found from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/20.' in caplog.text
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/21.' in caplog.text
+        assert 'No attachment sync failures found from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/21.' in caplog.text
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22.' in caplog.text
+        assert (
+            'Total number of failed attachment syncs from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22 is 1'
+        ) in caplog.text
+
+    def test_run_with_datestamp_param(self, sis_note_tables, app, caplog, metadata_db):
+        """When a datestamp is provided, validates files copied from the corresponding dated folder."""
+        with set_up_to_succeed(app, caplog):
+            response = VerifySisAdvisingNoteAttachments().run(datestamp='2018-12-22')
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22.' in caplog.text
+        assert 'No attachment sync failures found from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22.' in caplog.text
+        assert response == 'Note attachment verification completed successfully. No missing attachments or sync failures found.'
+
+        with set_up_to_fail(app, caplog):
+            response = VerifySisAdvisingNoteAttachments().run(datestamp='2018-12-22')
+        assert 'Will validate files from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22.' in caplog.text
+        assert (
+            'Total number of failed attachment syncs from sis-data/sis-sftp/incremental/advising-notes/attachment-files/2018/12/22 is 1'
+        ) in caplog.text


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-696

The Migrate and Verify jobs now share the code that constructs a range of dates from the last successful run of the Migrate job to today.

The dates are converted from UTC to PST to match the dated folder structure created by Darlene's script, which runs in PST.