### PR TITLE
NS-696: Further simplifies the verify attachments job

### DIFF
--- a/nessie/jobs/verify_sis_advising_note_attachments.py
+++ b/nessie/jobs/verify_sis_advising_note_attachments.py
@@ -27,8 +27,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from flask import current_app as app
 from nessie.externals import redshift, s3
 from nessie.jobs.background_job import BackgroundJob, BackgroundJobError
-from nessie.lib.metadata import most_recent_background_job_status
-from nessie.lib.util import get_s3_sis_attachment_current_paths, get_s3_sis_attachment_path
+from nessie.lib.util import get_s3_sis_attachment_path
 
 
 """Logic for validating SIS advising note attachments."""
@@ -61,12 +60,9 @@ class VerifySisAdvisingNoteAttachments(BackgroundJob):
             return f'Note attachment verification completed successfully. No missing attachments or sync failures found.'
 
     def source_paths(self, datestamp):
-        if datestamp and datestamp != 'since_successful_run':
+        if datestamp:
             return get_s3_sis_attachment_path(datestamp)
-
-        last_successful_run = most_recent_background_job_status('MigrateSisAdvisingNoteAttachments', 'succeeded')
-        begin_dt = last_successful_run.get('updated_at') if last_successful_run else None
-        return get_s3_sis_attachment_current_paths(begin_dt)
+        return [app.config['LOCH_S3_ADVISING_NOTE_ATTACHMENT_SOURCE_PATH']]
 
     def verify_attachment_migration(self, source_prefix, dest_prefix):
         s3_attachment_sync_failures = []

--- a/tests/test_lib/test_util.py
+++ b/tests/test_lib/test_util.py
@@ -51,6 +51,13 @@ class TestUtil:
         assert paths[2] == f'{prefix}/2019/09/21'
         assert paths[3] == f'{prefix}/2019/09/22'
 
+        # Start date is 9/25 5am UTC (9/24 10pm PST). Today is 9/26 5am UTC (9/25 10pm PST).
+        mock_datetime.utcnow.return_value = datetime(year=2019, month=9, day=26, hour=5)
+        paths = util.get_s3_sis_attachment_current_paths(datetime(year=2019, month=9, day=25, hour=5))
+        assert len(paths) == 2
+        assert paths[0] == f'{prefix}/2019/09/24'
+        assert paths[1] == f'{prefix}/2019/09/25'
+
         # Start date is 9/20 5am UTC (9/19 10pm PST). Today is 9/20 5pm UTC (9/20 10am PST)
         mock_datetime.utcnow.return_value = datetime(year=2019, month=9, day=20, hour=17)
         paths = util.get_s3_sis_attachment_current_paths(datetime(year=2019, month=9, day=20, hour=5))


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-696

Whereas the "since last successful run" logic has proved problematic for the VerifySisAdvisingNoteAttachments job, and whereas the work it does is inexpensive (relative to the Migrate job's work of copying files), the job will now validate all SIS attachments in S3 by default. 
 We can still narrow it down to a specific year, month, or date by running it manually with a datestamp param.