### PR TITLE
NS-682 Log & move past faulty JSON payloads from SIS API

### DIFF
--- a/nessie/externals/sis_student_api.py
+++ b/nessie/externals/sis_student_api.py
@@ -217,7 +217,18 @@ def authorized_request_v2(url):
         'app_key': app.config['STUDENT_API_KEY'],
         'Accept': 'application/json',
     }
-    return http.request(url, auth_headers)
+    response = http.request(url, auth_headers)
+    # We are occasionally receiving bad JSON payloads from the API and would like to know why.
+    try:
+        response and hasattr(response, 'json') and response.json()
+    except ValueError as e:
+        if hasattr(response, 'content'):
+            desc = response.content
+        else:
+            desc = response
+        app.logger.error(f'Error on API call {url}, response={desc}, error={e}')
+        return
+    return response
 
 
 def authorized_request_v1(url):


### PR DESCRIPTION
The latest turn of the screw from https://jira.ets.berkeley.edu/jira/browse/NS-682

This is kind of hokey but I couldn't come up with anything better. If we decide to leave the extra protection in place, we should refactor a bit so as to return the parsed JSON up the call stack instead of paying the decoding price twice.