### PR TITLE
NS-751, require 'setuptools>=30.0.0' per CodePipeline complaint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,5 @@ moto==1.3.6
 pytest==5.2.4
 pytest-flask==0.15.0
 responses==0.10.6
+setuptools>=30.0.0
 tox==3.13.2


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-751

I'm not convinced this will work. See Jira for log snippet from failed CodePipeline deploy.