### PR TITLE
NS-755: Increases instance size to m5.large

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -12,7 +12,7 @@ option_settings:
   aws:autoscaling:launchconfiguration:
     EC2KeyName: cloudlrs-aws-eb
     IamInstanceProfile: "$IAM_INSTANCE_PROFILE"
-    InstanceType: t2.small
+    InstanceType: m5.large
     SSHSourceRestriction: tcp, 22, 22, sg-0214f564372b01602
 
   aws:elasticbeanstalk:container:python:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-755

This intervention is needed because an AWS bug is causing this setting to override the console-side config.