### PR TITLE
NS-912, revert ldap3 to v2.7 (was v2.8)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Werkzeug==1.0.1
 apscheduler==3.6.3
 boto3==1.7.84
 decorator==4.4.2
-ldap3==2.8
+ldap3==2.7
 psycopg2-binary==2.8.5
 pytz==2020.1
 requests==2.24.0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-912

Nessie-dev jobs failed with "automatic start_tls befored bind not successful". Possibly due to recent ldap upgrade (PR #747). See "version 2.8 of ldap3 introduced SafeSync" at https://ldap3.readthedocs.io/en/latest/