### PR TITLE
NS-974, refactor routes in nessie piazza jobs

### DIFF
--- a/nessie/jobs/import_piazza_api_data.py
+++ b/nessie/jobs/import_piazza_api_data.py
@@ -38,7 +38,8 @@ import requests
 
 class ImportPiazzaApiData(BackgroundJob):
 
-    def run(self, frequency, datestamp, mock=None):
+    def run(self, archive=None):
+        frequency, datestamp, archive, s3_path = get_s3_piazza_data_path(archive)
         create_background_job_status(self.job_id)
         try:
             message = self.process_archives(frequency, datestamp, self.job_id)
@@ -50,7 +51,7 @@ class ImportPiazzaApiData(BackgroundJob):
         return True
 
     def process_archives(self, frequency, datestamp, job_id):
-        s3_key = get_s3_piazza_data_path()
+        s3_key = app.config['LOCH_S3_PIAZZA_DATA_PATH']
         self.sid = app.config['PIAZZA_API_SID']  # this is Piazza school ID for Berkeley
         self.session_id = app.config['PIAZZA_API_SESSIONID']  # a 'random string' but we still are getting it from config
         self.headers = {

--- a/nessie/lib/util.py
+++ b/nessie/lib/util.py
@@ -120,12 +120,14 @@ def get_s3_oua_daily_path(cutoff=None):
     return app.config['LOCH_S3_OUA_DATA_PATH'] + '/daily/' + hashed_datestamp(cutoff)
 
 
-def get_s3_piazza_data_path(path=None):
-    if path is None:
-        return app.config['LOCH_S3_PIAZZA_DATA_PATH']
-    elif path == 'latest':
-        path = strftime('daily/%Y/%m/%d/daily_%Y-%m-%d.zip')
-    return app.config['LOCH_S3_PIAZZA_DATA_PATH'] + f'/{path}'
+def get_s3_piazza_data_path(archive=None):
+    # archive need to be, or become, one of the piazza zip file names, without .zip, i.e. type-yyyy-mm-dd
+    if archive == 'latest' or archive is None:
+        archive = strftime('daily-%Y-%m-%d')
+    match = re.match(r'(\w+)\-(\d{4}\-\d{2}\-\d{2})', archive)
+    frequency = match[1]
+    datestamp = match[2]
+    return frequency, datestamp, archive, app.config['LOCH_S3_PIAZZA_DATA_PATH'] + '/' + archive.replace('-', '/')
 
 
 def get_s3_sis_attachment_current_paths(begin_dt=None):


### PR DESCRIPTION
As previously written, the Import job required that something be included in the URL to indicate to the job which archive to fetch (e.g. "daily-2020-09-12", or just "daily", for the latest daily zip). However, when running as a scheduled job this path element is not being provided and so it fails.

Same applies to the Transform job.

I have simplified the routes and made that path element optional, in which case it defaults to "latest", i.e. "daily-MMMM-YY-DD", for date of run.