### PR TITLE
NS-974, job queue entries only appear once now, correct filename parsing

### DIFF
--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -361,8 +361,8 @@ def import_non_current_students():
 @app.route('/api/job/import_piazza_api_data/<archive>', methods=['POST'])
 @auth_required
 def import_piazza_api_data(archive='latest'):
-    if not re.match('(daily|monthly|full|latest)', archive):
-        raise BadRequestError(f'Incorrect archive parameter "{archive}", should be "latest" or like "daily-2020-09-12".')
+    if not (re.match('(daily|monthly|full|latest)', archive) and re.match(r'(\w+)\_(\d{4}\-\d{2}\-\d{2})', archive)):
+        raise BadRequestError(f'Incorrect archive parameter "{archive}", should be "latest" or like "daily_2020-09-12".')
     job_started = ImportPiazzaApiData(archive=archive).run_async()
     return respond_with_status(job_started)
 

--- a/nessie/jobs/import_piazza_api_data.py
+++ b/nessie/jobs/import_piazza_api_data.py
@@ -29,7 +29,7 @@ from re import split
 from flask import current_app as app
 from nessie.externals import s3
 from nessie.jobs.background_job import BackgroundJob
-from nessie.lib.metadata import create_background_job_status, update_background_job_status
+from nessie.lib.metadata import update_background_job_status
 from nessie.lib.util import get_s3_piazza_data_path
 import requests
 
@@ -40,15 +40,7 @@ class ImportPiazzaApiData(BackgroundJob):
 
     def run(self, archive=None):
         frequency, datestamp, archive, s3_path = get_s3_piazza_data_path(archive)
-        create_background_job_status(self.job_id)
-        try:
-            message = self.process_archives(frequency, datestamp, self.job_id)
-            update_background_job_status(self.job_id, 'succeeded', details=message)
-        except Exception as e:
-            update_background_job_status(self.job_id, 'failed', details='error: ' + str(e))
-            app.logger.error(e)
-            return False
-        return True
+        return self.process_archives(frequency, datestamp, self.job_id)
 
     def process_archives(self, frequency, datestamp, job_id):
         s3_key = app.config['LOCH_S3_PIAZZA_DATA_PATH']

--- a/nessie/lib/util.py
+++ b/nessie/lib/util.py
@@ -125,13 +125,13 @@ def get_s3_oua_daily_path(cutoff=None):
 
 
 def get_s3_piazza_data_path(archive=None):
-    # archive need to be, or become, one of the piazza zip file names, without .zip, i.e. type-yyyy-mm-dd
+    # archive need to be, or become, one of the piazza zip file names, without .zip, i.e. type_yyyy-mm-dd
     if archive == 'latest' or archive is None:
-        archive = strftime('daily-%Y-%m-%d')
-    match = re.match(r'(\w+)\-(\d{4}\-\d{2}\-\d{2})', archive)
+        archive = strftime('daily_%Y-%m-%d')
+    match = re.match(r'(\w+)\_(\d{4}\-\d{2}\-\d{2})', archive)
     frequency = match[1]
     datestamp = match[2]
-    return frequency, datestamp, archive, app.config['LOCH_S3_PIAZZA_DATA_PATH'] + '/' + archive.replace('-', '/')
+    return frequency, datestamp, archive, app.config['LOCH_S3_PIAZZA_DATA_PATH'] + '/' + archive.replace('-', '/').replace('_', '/')
 
 
 def get_s3_sis_attachment_current_paths(begin_dt=None):


### PR DESCRIPTION
Correcting a couple "overdesign" and "overimplementation" issues:

1. Nessie itself makes job start and job end entries is the job queue. No need to do that twice! Doing so make two entries appear for each job.
2. Also realized that the previous implementation was not returning job queue 'details' properly, and so they were not appearing.
3. Refactored a bit to allow Nessie to take care of some error conditions, rather than try to do it myself with try: ... except: blocks. This simplified a bunch of things!
4. The optional "archive" value was not being parsed correctly. This wasn't causing a problem per se, but it should match the archive naming convention in use by Piazza.
