### PR TITLE
NS-1076, less config-related mixin code for Nessie front-end

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,12 @@ Vue.use(BootstrapVue)
 Vue.use(require('vue-moment'))
 Vue.use(VueLodash, { lodash })
 
-new Vue({
-  router,
-  store,
-  render: h => h(App)
-}).$mount('#app')
+axios.get(`${process.env.VUE_APP_API_BASE_URL}/api/config`).then(response => {
+  Vue.prototype.$config = response.data
+
+  new Vue({
+    router,
+    store,
+    render: h => h(App)
+  }).$mount('#app')
+})

--- a/src/mixins/Context.vue
+++ b/src/mixins/Context.vue
@@ -6,13 +6,7 @@ export default {
   computed: {
     ...mapGetters('context', [
       'apiBaseUrl',
-      'currentEnrollmentTermId',
-      'currentEnrollmentTerm',
-      'currentEnrollmentTermId',
-      'ebEnvironment',
       'errors',
-      'featureFlagEnterpriseDataLake',
-      'nessieEnv',
       'ping',
       'version'
     ])

--- a/src/router.ts
+++ b/src/router.ts
@@ -27,7 +27,7 @@ const registerMe = () => {
 }
 
 const beforeEach = (to: any, from: any, next: Function) => {
-  store.dispatch('context/loadConfig').then(() => {
+  store.dispatch('context/init').then(() => {
     store.dispatch('context/clearErrors').then(() => {
       const safeNext = (to: any, next: Function) => {
         if (to.matched.length) {

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -1,12 +1,10 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
-import _ from 'lodash'
-import { getConfig, getPing, getVersion } from '@/api/status'
+import {getPing, getVersion} from '@/api/status'
 
 Vue.use(Vuex)
 
 const state = {
-  config: undefined,
   errors: [],
   ping: undefined,
   version: undefined
@@ -14,11 +12,6 @@ const state = {
 
 const getters = {
   apiBaseUrl: (): any => process.env.VUE_APP_API_BASE_URL,
-  currentEnrollmentTermId: (state: any): boolean => _.get(state.config, 'currentEnrollmentTermId'),
-  currentEnrollmentTerm: (state: any): boolean => _.get(state.config, 'currentEnrollmentTerm'),
-  ebEnvironment: (state: any): string => _.get(state.config, 'ebEnvironment'),
-  featureFlagEnterpriseDataLake: (state: any): string => _.get(state.config, 'featureFlagEnterpriseDataLake'),
-  nessieEnv: (state: any): string => _.get(state.config, 'nessieEnv'),
   errors: (state: any): any => state.errors,
   ping: (state: any): any => state.ping,
   version: (state: any): any => state.version
@@ -36,29 +29,21 @@ const mutations = {
     error.id = new Date().getTime()
     state.errors.push(error)
   },
-  storeConfig: (state: any, config: any) => (state.config = config),
   storePing: (state: any, ping: any) => (state.ping = ping),
   storeVersion: (state: any, version: any) => (state.version = version)
 }
 
 const actions = {
   clearErrors: ({ commit }) => commit('clearErrors'),
-  loadConfig: ({ commit, state }) => {
-    return new Promise(resolve => {
-      if (state.config) {
-        resolve(state.config)
-      } else {
-        getPing().then(ping => {
-          commit('storePing', ping)
-          getVersion().then(version => {
-            commit('storeVersion', version)
-            getConfig().then(config => {
-              commit('storeConfig', config)
-              resolve(config)
-            })
-          })
+  init: ({ commit }) => {
+    return new Promise<void>(resolve => {
+      getPing().then(ping => {
+        commit('storePing', ping)
+        getVersion().then(version => {
+          commit('storeVersion', version)
+          resolve()
         })
-      }
+      })
     })
   }
 }

--- a/src/views/Status.vue
+++ b/src/views/Status.vue
@@ -1,35 +1,28 @@
 <template>
   <div>
-    <h1>Status</h1>
-    <h2>Ping</h2>
-    <div>
+    <h1>Nessie v{{ version.version }}</h1>
+    <h2>Config</h2>
+    <b-list-group class="w-50">
+      <b-list-group-item
+        v-for="(value, key) in $config"
+        :key="key"
+        class="d-flex justify-content-between align-items-center"
+      >
+        <b-badge pill variant="info"><span class="config-pill">{{ _.capitalize(decamelize(key)) }}</span></b-badge>
+        {{ value }}
+      </b-list-group-item>
+    </b-list-group>
+    <div class="py-3">
+      <h2>Build</h2>
+      <ul>
+        <li>Artifact: {{ version.build && version.build.artifact ? version.build.artifact : '--' }}</li>
+        <li>Git commit: {{ version.build && version.build.gitCommit ? version.build.gitCommit : '--' }}</li>
+      </ul>
+      <h2>Ping</h2>
       <ul>
         <li>App: {{ ping.app }}</li>
         <li>RDS: {{ ping.rds }}</li>
         <li>Redshift: {{ ping.redshift }}</li>
-      </ul>
-    </div>
-    <h2>Config</h2>
-    <div>
-      <ul>
-        <li>Nessie environment: {{ nessieEnv }}</li>
-        <li>EB environment: {{ ebEnvironment }}</li>
-        <li>Current Enrollment Term: {{ currentEnrollmentTerm }}</li>
-        <li>Current Enrollment Term ID: {{ currentEnrollmentTermId }}</li>
-        <li>EDL feature flag: {{ featureFlagEnterpriseDataLake }}</li>
-      </ul>
-    </div>
-    <h2>Version</h2>
-    <div>
-      <ul>
-        <li>Version: {{ version.version }}</li>
-        <li>
-          Build
-          <ul>
-            <li>Artifact: {{ version.build && version.build.artifact ? version.build.artifact : '--' }}</li>
-            <li>Git commit: {{ version.build && version.build.gitCommit ? version.build.gitCommit : '--' }}</li>
-          </ul>
-        </li>
       </ul>
     </div>
   </div>
@@ -39,6 +32,15 @@
 import Context from '@/mixins/Context'
 
 export default {
-  mixins: [Context]
+  mixins: [Context],
+  methods: {
+    decamelize: s => s.replace(/([a-z\d])([A-Z])/g, '$1 $2').replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1 $2')
+  }
 }
 </script>
+
+<style scoped>
+.config-pill {
+  font-size: 14px;
+}
+</style>

--- a/tests/test_api/test_status_controller.py
+++ b/tests/test_api/test_status_controller.py
@@ -31,7 +31,11 @@ class TestStatusController:
         """Returns a well-formed response."""
         response = client.get('/api/config')
         assert response.status_code == 200
-        assert response.json['nessieEnv'] == 'test'
+        api_json = response.json
+        assert api_json['ebEnvironment'] is None
+        assert api_json['featureFlagEnterpriseDataLake'] is False
+        assert api_json['jobSchedulingEnabled'] is True
+        assert api_json['nessieEnv'] == 'test'
 
     def test_ping(self, client):
         """Answers the phone when pinged."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1076

One more front-end tweak: I borrowed a snippet of Diablo code to simplify config-related mixin. Plus, a more informative and cleaner `/status` page.