### PR TITLE
NS-1081, get_s3_sis_api_daily_path has opt-in to use 'edl' S3 bucket

### DIFF
--- a/nessie/jobs/import_degree_progress.py
+++ b/nessie/jobs/import_degree_progress.py
@@ -68,7 +68,7 @@ class ImportDegreeProgress(BackgroundJob):
                 app.logger.error(f'SIS get_degree_progress failed for SID {csid}.')
             index += 1
 
-        s3_key = f'{get_s3_sis_api_daily_path()}/degree_progress.tsv'
+        s3_key = f'{get_s3_sis_api_daily_path(use_edl_if_feature_flag=True)}/degree_progress.tsv'
         app.logger.info(f'Will stash {success_count} feeds in S3: {s3_key}')
         if not s3.upload_tsv_rows(rows, s3_key):
             raise BackgroundJobError('Error on S3 upload: aborting job.')

--- a/nessie/jobs/import_registrations.py
+++ b/nessie/jobs/import_registrations.py
@@ -68,7 +68,7 @@ class ImportRegistrations(AbstractRegistrationsJob):
             raise BackgroundJobError('Failed to import registration histories: aborting job.')
 
         for key in rows.keys():
-            s3_key = f'{get_s3_sis_api_daily_path()}/{key}.tsv'
+            s3_key = f'{get_s3_sis_api_daily_path(use_edl_if_feature_flag=True)}/{key}.tsv'
             app.logger.info(f'Will stash {len(successes)} feeds in S3: {s3_key}')
             if not s3.upload_tsv_rows(rows[key], s3_key):
                 raise BackgroundJobError('Error on S3 upload: aborting job.')

--- a/nessie/lib/util.py
+++ b/nessie/lib/util.py
@@ -30,7 +30,7 @@ import re
 
 from dateutil.rrule import DAILY, rrule
 from flask import current_app as app
-from nessie.lib.berkeley import earliest_term_id
+from nessie.lib.berkeley import earliest_term_id, feature_flag_edl
 import pytz
 
 """Generic utilities."""
@@ -164,9 +164,11 @@ def get_s3_sis_attachment_path(datestamp):
         return ['/'.join([app.config['LOCH_S3_ADVISING_NOTE_ATTACHMENT_SOURCE_PATH']] + datestamp.split('-'))]
 
 
-def get_s3_sis_api_daily_path(cutoff=None):
+def get_s3_sis_api_daily_path(cutoff=None, use_edl_if_feature_flag=False):
     # Path for stashed SIS API data that doesn't need to be queried by Redshift Spectrum.
-    return app.config['LOCH_S3_SIS_API_DATA_PATH'] + '/daily/' + hashed_datestamp(cutoff)
+    use_edl = feature_flag_edl() and use_edl_if_feature_flag
+    key = 'LOCH_S3_EDL_DATA_PATH' if use_edl else 'LOCH_S3_SIS_API_DATA_PATH'
+    return f'{app.config[key]}/daily/{hashed_datestamp(cutoff)}'
 
 
 def get_s3_sis_daily_path(cutoff=None):

--- a/nessie/sql_templates/create_edl_schema.template.sql
+++ b/nessie/sql_templates/create_edl_schema.template.sql
@@ -51,7 +51,7 @@ SORTKEY (section_id)
 AS (
   WITH edl_classes AS (
     SELECT class_number, semester_year_term_cd, instructional_format_nm, class_section_cd, course_nm, course_title_long_nm, graded_section_flg, instruction_mode_cd,
-      /* TODO We find the max units actually enrolled as a placeholder for SIS max allowable units; this probably isn't 100% conformant. */
+      -- TODO: We find the max units actually enrolled as a placeholder for SIS max allowable units; this probably isn't 100% conformant.
       MAX(units) AS max_units
     FROM {redshift_schema_edl_external}.student_enrollment_data
     GROUP BY class_number, semester_year_term_cd, instructional_format_nm, class_section_cd, course_nm, course_title_long_nm, graded_section_flg, instruction_mode_cd
@@ -66,7 +66,7 @@ AS (
     edl_classes.graded_section_flg AS is_primary,
     edl_classes.max_units AS allowed_units,
     edl_classes.instruction_mode_cd AS instruction_mode,
-    /* TODO placeholder columns for meeting and instructor info pending EDW-248 resolution */
+    -- TODO: placeholder columns for meeting and instructor info pending EDW-248 resolution
     NULL AS instructor_uid,
     NULL AS instructor_name,
     NULL AS instructor_role_code,
@@ -95,7 +95,7 @@ AS (
     sed.grading_basis_enrollment_cd AS grading_basis,
     sed.midterm_course_grade_input_cs AS grade_midterm
   FROM {redshift_schema_edl_external}.student_enrollment_data sed
-  /* TODO temporarily attempting UID join from staging tables pending EDW-246 resolution */
+  -- TODO: temporarily attempting UID join from staging tables pending EDW-246 resolution
   LEFT JOIN {redshift_schema_edl_external_staging}.cs_ps_person_sa psa
     ON psa.emplid = sed.student_id
 );


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1081

Not all calls to `get_s3_sis_api_daily_path()` should use EDL bucket. Opt-in is safer.