### PR TITLE
NS-1091, put more failed-job info in alert_email

### DIFF
--- a/nessie/jobs/background_job.py
+++ b/nessie/jobs/background_job.py
@@ -125,7 +125,13 @@ class BackgroundJob(object):
                     status = 'failed'
                     details = error
                     send_system_error_email(
-                        message=details,
+                        message=f"""
+                            job_id: {self.job_id}
+
+                            job_args: {self.job_args}
+
+                            {details or 'No details.'}
+                        """,
                         subject=f'Job failure: {type(self).__name__}',
                     )
                 update_background_job_status(self.job_id, status, details=details)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1091

I also removed redundant `EMAIL_FEATURE_ENABLED` check. The diff is far simpler than it looks: review with `?w=1`. 