### PR TITLE
NS-1157 Removing EnhancedHealthAuthEnabled because default value is set to true

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -57,7 +57,6 @@ option_settings:
 
   aws:elasticbeanstalk:healthreporting:system:
     SystemType: enhanced
-    EnhancedHealthAuthEnabled: true
 
   aws:elasticbeanstalk:cloudwatch:logs:
     StreamLogs: true


### PR DESCRIPTION
Reversing EnhancedHealthAuthEnabled which had been added for testing purposes.