### PR TITLE
NS-1176 Remove misleading uid column from advisor/dept table

### DIFF
--- a/nessie/sql_templates/create_advisor_schema.template.sql
+++ b/nessie/sql_templates/create_advisor_schema.template.sql
@@ -143,7 +143,6 @@ SORTKEY (sid)
 AS (
     SELECT DISTINCT
       I.ADVISOR_ID AS sid,
-      I.CAMPUS_ID AS uid,
       I.ADVISOR_TYPE AS advisor_type_code,
       I.ADVISOR_TYPE_DESCR AS advisor_type,
       I.ACADEMIC_PLAN AS plan_code,
@@ -156,7 +155,6 @@ AS (
     UNION
     SELECT DISTINCT
       S.ADVISOR_ID AS sid,
-      S.CAMPUS_ID AS uid,
       S.ADVISOR_ROLE AS advisor_type_code,
       S.ADVISOR_ROLE_DESCR AS advisor_type,
       S.ACADEMIC_PLAN AS plan_code,

--- a/nessie/sql_templates/index_advisors.template.sql
+++ b/nessie/sql_templates/index_advisors.template.sql
@@ -67,7 +67,6 @@ DROP TABLE IF EXISTS {rds_schema_advisor}.advisor_departments CASCADE;
 
 CREATE TABLE {rds_schema_advisor}.advisor_departments (
    sid VARCHAR,
-   uid VARCHAR,
    advisor_type_code VARCHAR,
    advisor_type VARCHAR,
    plan_code VARCHAR,
@@ -79,14 +78,13 @@ CREATE TABLE {rds_schema_advisor}.advisor_departments (
 INSERT INTO {rds_schema_advisor}.advisor_departments (
   SELECT *
   FROM dblink('{rds_dblink_to_redshift}',$REDSHIFT$
-    SELECT sid, uid, advisor_type_code, advisor_type, plan_code, plan,
+    SELECT sid, advisor_type_code, advisor_type, plan_code, plan,
            department_code, department
     FROM {redshift_schema_advisor_internal}.advisor_departments
-    ORDER BY uid, plan_code
+    ORDER BY sid, plan_code
   $REDSHIFT$)
   AS redshift_advisor_departments (
     sid VARCHAR,
-    uid VARCHAR,
     advisor_type_code VARCHAR,
     advisor_type VARCHAR,
     plan_code VARCHAR,
@@ -96,7 +94,7 @@ INSERT INTO {rds_schema_advisor}.advisor_departments (
   )
 );
 
-CREATE INDEX idx_advisor_departments_uid ON {rds_schema_advisor}.advisor_departments(uid);
+CREATE INDEX idx_advisor_departments_sid ON {rds_schema_advisor}.advisor_departments(sid);
 CREATE INDEX idx_advisor_departments_plan_code ON {rds_schema_advisor}.advisor_departments(plan_code);
 CREATE INDEX idx_advisor_departments_department_code ON {rds_schema_advisor}.advisor_departments(department_code);
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1176

One more follow-up to #908. Traced back to the source, that column turns out to refer to student ids, not advisor ids.