### PR TITLE
NS-1189, upgrade to flake8 3.9.2 and fix lint-py errors

### DIFF
--- a/nessie/api/errors.py
+++ b/nessie/api/errors.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from nessie.lib.http import tolerant_jsonify
 
 
-class JsonableException(Exception):
+class JsonableError(Exception):
     def __init__(self, message):
         Exception.__init__(self)
         self.message = message
@@ -38,13 +38,13 @@ class JsonableException(Exception):
             return ''
 
 
-class BadRequestError(JsonableException):
+class BadRequestError(JsonableError):
     pass
 
 
-class UnauthorizedRequestError(JsonableException):
+class UnauthorizedRequestError(JsonableError):
     pass
 
 
-class ResourceNotFoundError(JsonableException):
+class ResourceNotFoundError(JsonableError):
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -27,18 +27,18 @@ commands = pytest --durations=10 {posargs: -p no:warnings tests}
 # Bottom of file has Flake8 settings
 commands = flake8 {posargs:config consoler.py nessie scripts tests run.py}
 deps =
-    flake8>=3.8.4
+    flake8>=3.9.2
     flake8-builtins>=1.5.3
-    flake8-colors>=0.1.6
+    flake8-colors>=0.1.9
     flake8-commas>=2.0.0
     flake8-docstrings>=1.5.0
     flake8-import-order>=0.18.1
     flake8-pytest>=1.3
     flake8-quotes>=3.2.0
     flake8-strict>=0.2.1
-    flake8-tidy-imports>=4.1.0
-    pep8-naming>=0.11.1
-    pydocstyle>=5.1.1
+    flake8-tidy-imports>=4.3.0
+    pep8-naming>=0.12.0
+    pydocstyle>=6.1.1
 
 [flake8]
 exclude =


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1189