### PR TITLE
NS-1294, status tab doesn't need version.build cuz it's in header

### DIFF
--- a/src/views/Status.vue
+++ b/src/views/Status.vue
@@ -16,11 +16,7 @@
 
 <script>
 export default {
-  data: () => ({
-    gitCommit: undefined
-  }),
   created() {
-    this.gitCommit = this.$_.get(this.version.build, 'gitCommit')
     this.$ready()
   },
   methods: {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1294
