### PR TITLE
NS-1243, postgres/python proc lang does not like f-strings

### DIFF
--- a/nessie/jobs/create_terms_schema.py
+++ b/nessie/jobs/create_terms_schema.py
@@ -49,9 +49,9 @@ class CreateTermsSchema(BackgroundJob):
         return 'SIS terms schema creation job completed.'
 
     def create_external_schema(self):
-        app.logger.info('Executing SQL...')
         redshift.drop_external_schema(redshift_schema)
         sql_template = 'create_terms_schema.template.sql' if feature_flag_edl else 'create_terms_schema_per_edo_db.template.sql'
+        app.logger.info(f'Executing {sql_template}...')
         resolved_ddl = resolve_sql_template(sql_template)
         if redshift.execute_ddl_script(resolved_ddl):
             verify_external_schema(redshift_schema, resolved_ddl)

--- a/nessie/sql_templates/create_terms_schema.template.sql
+++ b/nessie/sql_templates/create_terms_schema.template.sql
@@ -42,14 +42,14 @@ RETURNS VARCHAR
 STABLE
 AS $$
     term_id = str(term_id)
-    year = f'19{term_id[1:3]}' if term_id.startswith('1') else f'20{term_id[1:3]}'
+    year = ('19' + term_id[1:3]) if term_id.startswith('1') else ('20' + term_id[1:3])
     terms = {
         '2': 'Spring',
         '5': 'Summer',
         '8': 'Fall',
         '0': 'Winter',
     }
-    return f'{terms[term_id[3:4]]} {year}'
+    return (terms[term_id[3:4]] + ' ' + year)
 $$ language plpythonu;
 
 GRANT EXECUTE


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1243

See Jira for latest stack-trace. Previous version of the postgres function `deduce_term_name()` caused error in Postico console due to f-strings. 