### PR TITLE
NS-1245, EDL term defs: group by term_id, capturing min/max dates

### DIFF
--- a/nessie/jobs/create_terms_schema.py
+++ b/nessie/jobs/create_terms_schema.py
@@ -125,14 +125,14 @@ class CreateTermsSchema(BackgroundJob):
         rows = redshift.fetch(f"""
             SELECT
               semester_year_term_cd AS term_id,
-              session_begin_dt AS term_begins,
-              session_end_dt AS term_ends,
-              load_dt AS edl_load_date
+              TO_CHAR(MIN(session_begin_dt), 'YYYY-MM-DD') AS term_begins,
+              TO_CHAR(MAX(session_end_dt), 'YYYY-MM-DD') AS term_ends
             FROM {edl_external_schema()}.student_academic_terms_session_data
             WHERE
               semester_year_term_cd >= {app.config['EARLIEST_ACADEMIC_HISTORY_TERM_ID']}
               AND academic_career_cd = 'UGRD'
-            ORDER BY semester_year_term_cd, session_begin_dt
+            GROUP BY semester_year_term_cd
+            ORDER BY semester_year_term_cd
         """)
         decorated_rows = []
         for row in rows:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1245

For example, EDL gives us:
```
2105, 2010-05-24, 2010-07-02
2105, 2010-06-07, 2010-08-13
2105, 2010-06-21, 2010-08-13
2105, 2010-07-06, 2010-08-13
2105, 2010-07-26, 2010-08-13
```
We group by and put one row in RDS:
```
2105, 2010-05-24, 2010-08-13
```
