### PR TITLE
NS-1341, EDL get_all_sids query: WHERE academic_program_status_cd IN ('AC', 'CM')

### DIFF
--- a/nessie/lib/queries.py
+++ b/nessie/lib/queries.py
@@ -110,7 +110,7 @@ def get_all_student_ids():
             FROM {edl_external_schema()}.student_academic_plan_data
             WHERE
                 academic_career_cd='UGRD'
-                AND academic_program_status_cd='AC'
+                AND academic_program_status_cd IN ('AC', 'CM')
                 AND academic_plan_type_cd != 'MIN'
             UNION SELECT sid FROM {asc_schema()}.students
             UNION SELECT sid FROM {coe_schema()}.students


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1341

`ImportDegreeProgress` job uses EDL sourced SIDs and it has not been getting SIDs of 'Completed Program' students. Fyi, other jobs that use this same `get_all_sids()`:
* import_calnet_data
* import_registrations
* import_sis_student_api
* import_student_photos

All good?
