### PR TITLE
NS-1354, EDL academic_plan_data query tweak to match v2 student API

### DIFF
--- a/nessie/lib/queries.py
+++ b/nessie/lib/queries.py
@@ -413,7 +413,7 @@ def get_edl_plans():
         JOIN {edl_external_schema_staging()}.cs_ps_acad_prog cpap
           ON sapd.student_id = cpap.emplid
           AND sapd.academic_program_cd = cpap.acad_prog
-          AND cpap.prog_action = 'MATR'
+          AND cpap.prog_action IN ('DATA', 'MATR')
         ORDER BY sapd.student_id, sapd.academic_career_cd, sapd.academic_program_cd"""
     return redshift.fetch(sql)
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1354

We pick up the expected `matriculation_term_cd`, matching v2 API results.