### PR TITLE
NS-1354, PRGC is acceptable statusInPlan.code when querying edl_plans

### DIFF
--- a/nessie/lib/queries.py
+++ b/nessie/lib/queries.py
@@ -387,7 +387,7 @@ def stream_edl_plans():
         JOIN {edl_external_schema_staging()}.cs_ps_acad_prog cpap
           ON sapd.student_id = cpap.emplid
           AND sapd.academic_program_cd = cpap.acad_prog
-          AND cpap.prog_action IN ('DATA', 'MATR')
+          AND cpap.prog_action IN ('DATA', 'MATR', 'PRGC')
         ORDER BY sapd.student_id, sapd.academic_career_cd, sapd.academic_program_cd"""
     return redshift.fetch(sql, stream_results=True)
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1354

See latest comment/screenshot in Jira above. This query tweak is in line with what we have been extracting from v2 student API.