### PR TITLE
NS-1370, when deducing level, include future terms iff term_enrolled_units > 0

### DIFF
--- a/nessie/lib/queries.py
+++ b/nessie/lib/queries.py
@@ -25,7 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from flask import current_app as app
 from nessie.externals import rds, redshift, s3
-from nessie.lib.berkeley import canvas_terms, reverse_term_ids, term_name_for_sis_id
+from nessie.lib.berkeley import canvas_terms, current_term_id, reverse_term_ids, term_name_for_sis_id
 from nessie.lib.mockingdata import fixture
 
 # Lazy init to support testing.
@@ -452,8 +452,18 @@ def stream_edl_registrations():
               FROM {edl_external_schema()}.student_registration_term_data r
               JOIN {edl_external_schema_staging()}.cs_ps_stdnt_car_term s
                 ON r.student_id = s.emplid AND r.semester_year_term_cd = s.strm
-              WHERE (r.term_enrolled_units IS NOT NULL AND r.term_enrolled_units > 0)
-                OR (r.term_berkeley_completed_total_units IS NOT NULL AND r.term_berkeley_completed_total_units > 0)
+              WHERE
+                (r.term_berkeley_completed_total_units IS NOT NULL AND r.term_berkeley_completed_total_units > 0)
+                OR
+                (
+                    r.term_enrolled_units IS NOT NULL
+                    AND
+                    (
+                        r.semester_year_term_cd <= '{current_term_id()}'
+                        OR
+                        (r.term_enrolled_units > 0 AND r.semester_year_term_cd > '{current_term_id()}')
+                    )
+                )
               ORDER BY r.student_id, r.semester_year_term_cd
         """
     return redshift.fetch(sql, stream_results=True)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-1370

PR #1051 was the first try at a fix but we were getting future terms w/ zero enrolled units.