### PR TITLE
NS-1232, remove openssl-devel (00_ami.config) to remove mod24 dep

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -7,7 +7,6 @@ packages:
     gcc-c++: []
     git: []
     mod_ssl: []
-    openssl-devel: []
 
 option_settings:
   aws:elasticbeanstalk:cloudwatch:logs:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1232