### PR TITLE
NS-1232, factory.py still had master/worker refs

### DIFF
--- a/application.py
+++ b/application.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 import os
 import subprocess
 
@@ -43,9 +42,9 @@ Usage mode B:
 
 # When running under WSGI, system environment variables are not automatically made available to Python code, and
 # an app restart will result in configurations being lost. We work around this with an explicit load from the shell
-# environment, sourcing from the Elastic Beanstalk-provided /var/app/current/env file if available.
+# environment.
 if __name__.startswith('_mod_wsgi'):
-    command = ['bash', '-c', '{ source /var/app/current/env || true; } && env']
+    command = ['bash', '-c', 'env']
     shell_environment = subprocess.Popen(command, stdout=subprocess.PIPE)
     for line in shell_environment.stdout:
         key, _, value = line.decode('utf-8').rstrip().partition('=')

--- a/config/default.py
+++ b/config/default.py
@@ -117,8 +117,8 @@ FEATURE_FLAG_EDL_REGISTRATIONS = False
 FEATURE_FLAG_EDL_SIS_VIEWS = False
 FEATURE_FLAG_EDL_STUDENT_PROFILES = False
 
-# True on master node, false on worker nodes.
-# Override by embedding "master" or "worker" in the EB_ENVIRONMENT environment variable.
+# True on 'highlands' node, false on 'lowlands' nodes.
+# Override by embedding "highlands" or "lowlands" in the EB_ENVIRONMENT environment variable.
 JOB_SCHEDULING_ENABLED = True
 
 # See http://apscheduler.readthedocs.io/en/latest/modules/triggers/cron.html for supported schedule formats.
@@ -307,7 +307,7 @@ VUE_LOCALHOST_BASE_URL = None
 
 WORKER_HOST = 'hard-working-nessie.berkeley.edu'
 
-# Thread queues will be ignored if "master" is embedded in the EB_ENVIRONMENT environment variable.
+# Thread queues will be ignored if "highlands" is embedded in the EB_ENVIRONMENT environment variable.
 WORKER_QUEUE_ENABLED = True
 WORKER_THREADS = 5
 

--- a/nessie/factory.py
+++ b/nessie/factory.py
@@ -56,13 +56,13 @@ def create_app():
 
 
 def configure_scheduler_mode(app):
-    """Determine whether this app instance is running as 'master' or 'worker'."""
+    """Determine whether this app instance is running as 'highlands' or 'lowlands'."""
     default_scheduler_mode = app.config['JOB_SCHEDULING_ENABLED']
     eb_environment = os.environ.get('EB_ENVIRONMENT')
     if eb_environment is not None:
-        if 'worker' in eb_environment:
+        if 'lowlands' in eb_environment:
             override_mode = False
-        elif 'master' in eb_environment:
+        elif 'highlands' in eb_environment:
             override_mode = True
             if app.config['WORKER_QUEUE_ENABLED']:
                 app.logger.info('Changing WORKER_QUEUE_ENABLED to False')

--- a/nessie/lib/dispatcher.py
+++ b/nessie/lib/dispatcher.py
@@ -30,7 +30,7 @@ from flask import current_app as app
 from nessie.lib import http
 from nessie.lib.mockingbird import fixture
 
-"""Client code allowing a master instance to dispatch requests to workers."""
+"""Client code allowing a 'highlands' instance to dispatch requests to the 'lowlands'."""
 
 
 @fixture('dispatch_{command}')

--- a/scripts/deploy_nessie_config.sh
+++ b/scripts/deploy_nessie_config.sh
@@ -3,7 +3,7 @@
 # -------------------------------------------------------------------
 #
 # Copy appropriate config file from S3 to production-local.py. This
-# script must be run on the target EC2 instance (eg, nessie-master-dev).
+# script must be run on the target EC2 instance.
 #
 # -------------------------------------------------------------------
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -39,14 +39,14 @@ class TestFactory:
 
     def test_disable_scheduling_through_env(self, app):
         with override_config(app, 'JOB_SCHEDULING_ENABLED', True):
-            os.environ['EB_ENVIRONMENT'] = 'nessie-worker-bee'
+            os.environ['EB_ENVIRONMENT'] = 'nessie-lowlands-bee'
             factory.configure_scheduler_mode(app)
             assert app.config['JOB_SCHEDULING_ENABLED'] is False
             assert app.config['WORKER_QUEUE_ENABLED'] is True
 
     def test_no_thread_limits_if_master_env(self, app):
         with override_config(app, 'JOB_SCHEDULING_ENABLED', True):
-            os.environ['EB_ENVIRONMENT'] = 'nessie-master-bee'
+            os.environ['EB_ENVIRONMENT'] = 'nessie-highlands-bee'
             factory.configure_scheduler_mode(app)
             assert app.config['JOB_SCHEDULING_ENABLED'] is True
             assert app.config['WORKER_QUEUE_ENABLED'] is False

--- a/tests/test_lib/test_dispatcher.py
+++ b/tests/test_lib/test_dispatcher.py
@@ -29,7 +29,7 @@ from tests.util import capture_app_logs
 
 
 class TestDispatcher:
-    """Master-to-worker dispatcher."""
+    """highlands-to-lowlands dispatcher."""
 
     def test_dispatch_fixture(self, app):
         """Returns fixture data."""


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1232

Get 'worker' out of the `factory.py`.