### PR TITLE
BOAC-4485, max/min_units_allowed for all terms enrolled (Nessie SQL)

### DIFF
--- a/nessie/merged/sis_profile.py
+++ b/nessie/merged/sis_profile.py
@@ -212,13 +212,10 @@ def merge_registration(sis_profile_feed, last_registration_feed, sis_profile):
 
     if total_units:
         sis_profile['currentTerm'] = {}
-        units_min = to_float(total_units.get('unitsMin')) or None
-        # For reasons we are working to understand, if a student does not have a 'unitsMinOverride' then SIS assigns a
-        # default of termUnits.unitsMin = 0.5. Thus, a student carrying 3 units in the current term will NOT be flagged
-        # as units-deficient. As a result, the system will not recognize the need to alert advisors.
-        # TODO: Until SISRP-48560 is resolved we will treat "0.5" as "12", the expected min units value.
-        sis_profile['currentTerm']['unitsMin'] = 12 if units_min == 0.5 else units_min
-        sis_profile['currentTerm']['unitsMax'] = to_float(total_units.get('unitsMax'))
+        units_max = total_units.get('unitsMax')
+        sis_profile['currentTerm']['unitsMax'] = to_float(units_max) if units_max is not None else None
+        units_min = total_units.get('unitsMin')
+        sis_profile['currentTerm']['unitsMin'] = to_float(units_min) if units_min is not None else None
 
     # TODO Should we also check for ['academicStanding']['status'] == {'code': 'DIS', 'description': 'Dismissed'}?
     withdrawal_cancel = registration.get('withdrawalCancel', {})

--- a/nessie/merged/student_terms.py
+++ b/nessie/merged/student_terms.py
@@ -119,6 +119,9 @@ def merge_enrollment(enrollments, term_id, term_name):
     enrollments_by_class = {}
     term_section_ids = {}
     enrolled_units = 0
+    max_term_units_allowed = None
+    min_term_units_allowed = None
+
     for enrollment in enrollments:
         # Skip this class section if we've seen it already.
         section_id = enrollment.get('sis_section_id')
@@ -165,6 +168,9 @@ def merge_enrollment(enrollments, term_id, term_name):
             enrollments_by_class[class_name]['midtermGrade'] = section_feed['midtermGrade']
             enrollments_by_class[class_name]['gradingBasis'] = section_feed['gradingBasis']
             enrollments_by_class[class_name]['units'] = section_feed['units']
+        if max_term_units_allowed is None:
+            max_term_units_allowed = enrollment['max_term_units_allowed']
+            min_term_units_allowed = enrollment['min_term_units_allowed']
 
     enrollments_feed = sorted(enrollments_by_class.values(), key=lambda x: x['displayName'])
     # Whenever we have floating arithmetic, we can expect floating errors.
@@ -176,6 +182,8 @@ def merge_enrollment(enrollments, term_id, term_name):
         'enrollments': enrollments_feed,
         'enrolledUnits': _to_float_cautiously(enrolled_units),
         'unmatchedCanvasSites': [],
+        'maxTermUnitsAllowed': max_term_units_allowed,
+        'minTermUnitsAllowed': min_term_units_allowed,
     }
     return term_feed
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4485

Previously, we stored max/min of current term only.