### PR TITLE
NOJIRA, change label of Nessie 'Status' tab

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,7 @@
       <b-col>
         <b-tabs v-if="$currentUser" v-model="tabIndex" align="center">
           <b-tab
-            v-for="(path, title, index) in {Jobs: '/home', Schedule: '/schedule', Status: '/status'}"
+            v-for="(path, title, index) in {Jobs: '/home', Schedule: '/schedule', Configs: '/status'}"
             :key="title"
             :active="path === $route.path"
             :title="title"


### PR DESCRIPTION
Previous PR did wake up nessie-dev CodePipeline, as we hoped. This final test is verifying that ets-readonly demotion (w.r.t Github rights) does not break our setup.