### PR TITLE
BOAC-4604, remove created_at from RDS table {history_dept}.advising_notes

### DIFF
--- a/nessie/sql_templates/index_history_dept_advising.template.sql
+++ b/nessie/sql_templates/index_history_dept_advising.template.sql
@@ -37,7 +37,6 @@ CREATE TABLE {rds_schema_history_dept}.advising_notes (
   student_first_name VARCHAR,
   student_last_name VARCHAR,
   note TEXT,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4604

`created_at` is not provided in the `tsv` provided.