### PR TITLE
BOAC-4524, Nessie gets post-deploy Cloudwatch hook

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -4,6 +4,7 @@
 
 packages:
   yum:
+    awslogs: []
     gcc-c++: []
     git: []
     mod_ssl: []
@@ -19,24 +20,22 @@ option_settings:
     /static: dist/static
 
 files:
-  /etc/awslogs/config/nessie_log.conf:
+  /etc/awslogs/awscli.conf:
+    mode: '000600'
+    owner: root
+    group: root
+    content: |
+      [plugins]
+      cwlogs = cwlogs
+      [default]
+      region = `{"Ref":"AWS::Region"}`
+
+  /etc/awslogs/config/logs.conf:
     mode: '000644'
     owner: root
     group: root
     content: |
-      {
-        "logs": {
-          "logs_collected": {
-            "files": {
-              "collect_list": [
-                {
-                  "file_path": "/var/app/current/nessie.log",
-                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/nessie.log"]]}`",
-                  "log_stream_name": "{instance_id}"
-                }
-              ]
-            }
-          },
-          "force_flush_interval" : 15
-        }
-      }
+      [/var/app/current/nessie.log]
+      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/nessie.log"]]}`
+      log_stream_name={instance_id}
+      file=/var/app/current/nessie.log*

--- a/.platform/hooks/postdeploy/01_start_awslogsd.sh
+++ b/.platform/hooks/postdeploy/01_start_awslogsd.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo systemctl enable awslogsd.service
+sudo systemctl restart awslogsd


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4524

As seen in recent BOA PRs.

Shell script perms:
```
ls -la .platform/hooks/postdeploy/01_start_awslogsd.sh

-rwxr-xr-x   ...   .platform/hooks/postdeploy/01_start_awslogsd.sh
```