### PR TITLE
BOAC-4612, unreliable JOIN clause w.r.t academic_standing_effective_dt_seq

### DIFF
--- a/nessie/sql_templates/create_edl_schema.template.sql
+++ b/nessie/sql_templates/create_edl_schema.template.sql
@@ -112,7 +112,6 @@ AS (
         ON s.student_id = latest_actions.student_id
         AND s.semester_year_term_cd = latest_actions.semester_year_term_cd
         AND s.action_dt = latest_actions.action_dt
-        AND s.academic_standing_effective_dt_seq = latest_actions.seq_nr
         AND s.academic_standing_effective_dt = latest_actions.eff_dt
     WHERE
         s.academic_standing_category_cd IS NOT NULL


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4612

This rolls back one line of a [recent change in create_edl_schema.template.sql](https://github.com/ets-berkeley-edu/nessie/commit/ff099d5ad03645ff964270df69755c3efe3cde01#diff-1025cd11792b5fdda5d8a7c5ff99fdddbccc0e0f3d3bb74bae835a92326fbf39L103).  

@lyttam - Seem okay? I have not rolled back your change to `(SELECT ...) AS latest_actions` clause.