### PR TITLE
BOAC-4612 Adjust logic to pull latest academic standing per term

### DIFF
--- a/nessie/sql_templates/create_edl_schema.template.sql
+++ b/nessie/sql_templates/create_edl_schema.template.sql
@@ -103,17 +103,14 @@ AS (
         s.action_dt AS action_date
     FROM {redshift_schema_edl_external}.student_academic_standing_data s
     JOIN (
-      SELECT student_id, semester_year_term_cd, MAX(action_dt) AS action_dt, 
-          MAX(academic_standing_effective_dt_seq) AS seq_nr, MAX(academic_standing_effective_dt) AS eff_dt
+      SELECT student_id, semester_year_term_cd, 
+      MAX(academic_standing_effective_dt || academic_standing_effective_dt_seq) AS eff_dt_seq
       FROM {redshift_schema_edl_external}.student_academic_standing_data
-      JOIN {redshift_schema_calnet}.advisees a ON a.sid = student_id
       GROUP BY student_id, semester_year_term_cd
     ) latest_actions
         ON s.student_id = latest_actions.student_id
         AND s.semester_year_term_cd = latest_actions.semester_year_term_cd
-        AND s.action_dt = latest_actions.action_dt
-        AND s.academic_standing_effective_dt_seq = latest_actions.seq_nr
-        AND s.academic_standing_effective_dt = latest_actions.eff_dt
+        AND s.academic_standing_effective_dt || s.academic_standing_effective_dt_seq = latest_actions.eff_dt_seq
     WHERE
         s.academic_standing_category_cd IS NOT NULL
         AND s.academic_standing_category_cd != ''


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4612

#1178 was right that we should be running our MAX aggregate not on action date, but on effective date + sequence number. The trick is that we can't use multiple MAX expressions, because if different columns have different max values the join will fail. So we concatenate first and apply MAX to the concatenation.