### PR TITLE
DIABLO-717,  Nessie > our EDL query must include 'meeting' instances not mapped to instructor(s)

### DIFF
--- a/nessie/sql_templates/create_edl_schema.template.sql
+++ b/nessie/sql_templates/create_edl_schema.template.sql
@@ -236,7 +236,7 @@ AS (
   LEFT JOIN {redshift_schema_edl_external}.student_class_meeting_pattern_data meet
     ON class.class_number = meet.class_number
     AND class.semester_year_term_cd = meet.semester_year_term_cd
-    AND (meet.class_meeting_number = instr.class_meeting_number OR instr.class_meeting_number IS NULL)
+    AND (meet.class_meeting_number IS NOT NULL OR instr.class_meeting_number IS NULL)
 );
 
 CREATE TABLE {redshift_schema_edl}.enrollments


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/DIABLO-717

Read latest comments in the Jira. Afaik, the only alternative to the relaxed WHERE clause in this PR is a crazy `DISTINCT` to avoid dupes:
```
DISTINCT(i.semester_year_term_cd || '' || i.class_number || '' || i.instructor_calnet_uid || '-' || i.class_meeting_number || '-' || m.class_meeting_number) AS key,
``` 

Feedback welcome. cc: @pauline2k 
