### PR TITLE
BOAC-3952: Added migration scripts to add division column to student majors

### DIFF
--- a/nessie/sql_templates/create_rds_indexes.template.sql
+++ b/nessie/sql_templates/create_rds_indexes.template.sql
@@ -172,6 +172,7 @@ CREATE TABLE IF NOT EXISTS {rds_schema_student}.student_majors
 CREATE INDEX IF NOT EXISTS student_majors_sid_idx ON {rds_schema_student}.student_majors (sid);
 CREATE INDEX IF NOT EXISTS student_majors_college_idx ON {rds_schema_student}.student_majors (college);
 CREATE INDEX IF NOT EXISTS student_majors_major_idx ON {rds_schema_student}.student_majors (major);
+CREATE INDEX IF NOT EXISTS student_majors_division_idx ON {rds_schema_student}.student_majors (division);
 
 CREATE TABLE IF NOT EXISTS {rds_schema_student}.demographics
 (

--- a/nessie/sql_templates/update_rds_indexes_student_profiles.template.sql
+++ b/nessie/sql_templates/update_rds_indexes_student_profiles.template.sql
@@ -222,10 +222,8 @@ TRUNCATE {rds_schema_student}.student_majors;
 INSERT INTO {rds_schema_student}.student_majors (
   SELECT *
   FROM dblink('{rds_dblink_to_redshift}',$REDSHIFT$
-      SELECT DISTINCT sid, m.college, m.major, s.academic_division_shrt_nm
-      FROM {redshift_schema_student}.student_majors m
-      JOIN {redshift_schema_edl_external}.student_academic_plan_hierarchy_data s
-      ON m.major = s.academic_plan_nm
+      SELECT DISTINCT sid, college, major, division
+      FROM {redshift_schema_student}.student_majors
     $REDSHIFT$)
   AS redshift_majors (
       sid VARCHAR,

--- a/scripts/migrate/20220329-BOAC-3952/rds_pre_deploy_01_add_division.sql
+++ b/scripts/migrate/20220329-BOAC-3952/rds_pre_deploy_01_add_division.sql
@@ -1,0 +1,24 @@
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS student.student_majors_new
+(
+    sid VARCHAR NOT NULL,
+    college VARCHAR NOT NULL,
+    major VARCHAR NOT NULL,
+    division VARCHAR
+);
+
+INSERT INTO student.student_majors_new (
+  SELECT sid, college, major, NULL FROM student.student_majors
+);
+
+DROP TABLE student.student_majors;
+
+ALTER TABLE student.student_majors_new RENAME TO student_majors;
+
+CREATE INDEX IF NOT EXISTS student_majors_sid_idx ON student.student_majors (sid);
+CREATE INDEX IF NOT EXISTS student_majors_college_idx ON student.student_majors (college);
+CREATE INDEX IF NOT EXISTS student_majors_major_idx ON student.student_majors (major);
+CREATE INDEX IF NOT EXISTS student_majors_division_idx ON student.student_majors (division);
+
+COMMIT;


### PR DESCRIPTION
Is 
``` sql
CREATE TABLE student_staging.student_majors
(
  sid VARCHAR NOT NULL,
  college VARCHAR NOT NULL,
  major VARCHAR NOT NULL,
  division VARCHAR
)
DISTKEY (sid)
SORTKEY (college, major, division);
```

correct here? I may have followed the colleges example a little too closely