### PR TITLE
BOAC-4777, botocore.ConnectionError requires named constructor arg

### DIFF
--- a/nessie/externals/s3.py
+++ b/nessie/externals/s3.py
@@ -249,7 +249,7 @@ def upload_from_response(response, s3_key, on_stream_opened=None):
         app.logger.error(
             f'Received unexpected status code, aborting S3 upload '
             f'(status={response.status_code}, body={response.text}, key={s3_key})')
-        raise ConnectionError(f'Response {response.status_code}: {response.text}')
+        raise ConnectionError(error=f'Response {response.status_code}: {response.text}')
     if on_stream_opened:
         on_stream_opened(response.headers)
     try:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4777

I believe BOAC-4777 has two concerns:
* timeout during `s3.upload_from_response`
* incorrect use of  ConnectionError constructor

This PR fixes #2, which will remove a distraction from the logged error.