### PR TITLE
BOAC-4886 Restore dropped courses to term feeds

### DIFF
--- a/nessie/jobs/generate_merged_student_feeds.py
+++ b/nessie/jobs/generate_merged_student_feeds.py
@@ -380,7 +380,7 @@ class GenerateMergedStudentFeeds(BackgroundJob):
                 if not term_feed:
                     term_feed = empty_term_feed(term_id, term_name)
                 append_drops(term_feed, enrollments_subgroup)
-            return term_feed, incompletes_row_count
+        return term_feed, incompletes_row_count
 
     def refresh_rds_enrollment_terms(self):
         resolved_ddl_rds = resolve_sql_template('update_rds_indexes_student_enrollment_terms.template.sql')


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4886

There's a lot to love about Python, but I think this blessed little significant indent mistake (from #1318) is why dropped courses have disappeared in production BOA.