### PR TITLE
Deploy hook update for Amazon Linux 2023

### DIFF
--- a/.platform/hooks/postdeploy/01_start_awslogsd.sh
+++ b/.platform/hooks/postdeploy/01_start_awslogsd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-sudo systemctl enable awslogsd.service
-sudo systemctl restart awslogsd
+
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s

--- a/.platform/hooks/predeploy/02_secure_sshd_configs.sh
+++ b/.platform/hooks/predeploy/02_secure_sshd_configs.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-PYTHONPATH='' aws s3 cp s3://la-deploy-configs/shared/security/CIS-OS-Security-Config-Benchmarks-1.0/sshd_config/sed_commands_default.v1
-sudo chown root:root /etc/ssh/sshd_config
-sudo chmod og-rwx /etc/ssh/sshd_config
-sudo cp -p /etc/ssh/sshd_config /etc/ssh/sshd_config.default
-sudo cp -p /etc/ssh/sshd_config /etc/ssh/sshd_config.new
-sudo test -f /tmp/sed_commands && sudo sed -i -f /tmp/sed_commands /etc/ssh/sshd_config.new
-sudo /usr/sbin/sshd -t -f /etc/ssh/sshd_config.new && sudo mv /etc/ssh/sshd_config.new /etc/ssh/sshd_config


### PR DESCRIPTION
The amazon log agent is replaced by cloudwatch logs agent, and the CIS benchmark covers all aspects of securing sshd configuration.