### PR TITLE
[NS-1649] Removing RefreshCanvasDataCatalog from the GenerateAllTables chained job. CD1 feed is deprecated.

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -125,8 +125,6 @@ JOB_SCHEDULING_ENABLED = True
 
 # See http://apscheduler.readthedocs.io/en/latest/modules/triggers/cron.html for supported schedule formats.
 # Schedules should be provided as dictionaries in configs, e.g. {'hour': 12, 'minute': 30}
-JOB_SYNC_CANVAS_SNAPSHOTS = {}
-JOB_RESYNC_CANVAS_SNAPSHOTS = {}
 JOB_SYNC_CANVAS_DATA_2_SNAPSHOTS = {}
 JOB_REFRESH_SISEDO_FULL = {}
 JOB_REFRESH_SISEDO_INCREMENTAL = {}

--- a/nessie/jobs/scheduling.py
+++ b/nessie/jobs/scheduling.py
@@ -94,16 +94,11 @@ def schedule_all_jobs(force=False):
     from nessie.jobs.query_canvas_data_2_snapshot import QueryCanvasData2Snapshot
     from nessie.jobs.refresh_boac_cache import RefreshBoacCache
     from nessie.jobs.refresh_canvas_data_2_schema import RefreshCanvasData2Schema
-    from nessie.jobs.refresh_canvas_data_catalog import RefreshCanvasDataCatalog
     from nessie.jobs.refresh_sisedo_schema_full import RefreshSisedoSchemaFull
     from nessie.jobs.refresh_sisedo_schema_incremental import RefreshSisedoSchemaIncremental
-    from nessie.jobs.resync_canvas_snapshots import ResyncCanvasSnapshots
-    from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
     from nessie.jobs.transform_piazza_api_data import TransformPiazzaApiData
     from nessie.jobs.verify_sis_advising_note_attachments import VerifySisAdvisingNoteAttachments
 
-    schedule_job(sched, 'JOB_SYNC_CANVAS_SNAPSHOTS', SyncCanvasSnapshots, force)
-    schedule_job(sched, 'JOB_RESYNC_CANVAS_SNAPSHOTS', ResyncCanvasSnapshots, force)
     schedule_job(sched, 'JOB_IMPORT_ADVISORS', CreateAdvisorSchema, force)
     schedule_job(sched, 'JOB_IMPORT_ADMISSIONS', CreateOUASchema, force)
     schedule_job(sched, 'JOB_REFRESH_SISEDO_FULL', RefreshSisedoSchemaFull, force)
@@ -124,7 +119,6 @@ def schedule_all_jobs(force=False):
         'JOB_GENERATE_ALL_TABLES',
         [
             CreateTermsSchema,
-            RefreshCanvasDataCatalog,
             GenerateIntermediateTables,
             IndexEnrollments,
             GenerateBoacAnalytics,


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1649
