### PR TITLE
[NS-1661] Trigger Query snapshot for CD2 job component with metadata updates

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -97,6 +97,7 @@ CANVAS_HTTP_TOKENS = ['yet another secret', 'in a list of secrets']
 
 CD2_SECRET_NAME = '<secret-string>'
 CD2_INGEST_LAMBDA_NAME = '<lambda name>'
+CD2_DYNAMODB_METADATA_TABLE = '<dynamoDB CD2 metadata table>'
 CD2_ZERO_COUNT_ACCEPTABLE = False
 
 # If set to 'auto', the next three items will use defaults based on SIS term definitions.

--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -74,6 +74,7 @@ from nessie.jobs.sync_canvas_requests_snapshots import SyncCanvasRequestsSnapsho
 from nessie.jobs.sync_canvas_snapshots import SyncCanvasSnapshots
 from nessie.jobs.sync_file_to_s3 import SyncFileToS3
 from nessie.jobs.transform_piazza_api_data import TransformPiazzaApiData
+from nessie.jobs.trigger_cd2_query_jobs import TriggerCD2QueryJobs
 from nessie.jobs.verify_sis_advising_note_attachments import VerifySisAdvisingNoteAttachments
 from nessie.lib.http import tolerant_jsonify
 from nessie.lib.metadata import update_canvas_sync_status
@@ -409,6 +410,13 @@ def sync_file_to_s3():
     if canvas_sync_job_id:
         update_canvas_sync_status(canvas_sync_job_id, key, 'received')
     job_started = SyncFileToS3(url=url, key=key, canvas_sync_job_id=canvas_sync_job_id).run_async()
+    return respond_with_status(job_started)
+
+
+@app.route('/api/job/trigger_cd2_query_jobs', methods=['POST'])
+@auth_required
+def trigger_cd2_query_jobs():
+    job_started = TriggerCD2QueryJobs.run_async()
     return respond_with_status(job_started)
 
 

--- a/nessie/jobs/trigger_cd2_query_jobs.py
+++ b/nessie/jobs/trigger_cd2_query_jobs.py
@@ -1,0 +1,102 @@
+"""
+Copyright ©2024. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from datetime import datetime, timezone
+import time
+
+from flask import current_app as app
+from nessie.externals import canvas_data_2, dynamodb
+from nessie.jobs.background_job import BackgroundJob
+
+
+"""Logic to trigger query Canvas Data 2 snapshot job with Instructure."""
+
+
+class TriggerCD2QueryJobs(BackgroundJob):
+
+    @classmethod
+    def generate_job_id(cls):
+        return 'TriggerCD2QueryJobs_' + str(int(time.time()))
+
+    def insert_cd2_metadata(self, namespace, table_query_jobs, nessie_job_id):
+        try:
+            # Use DynamoDB resource instead of client
+            dynamodb_resource = dynamodb.get_client()
+
+            environment_name = app.config['LOCH_S3_BUCKET']
+
+            # Change table name dynamically as needed
+            table = dynamodb_resource.Table(app.config['CD2_DYNAMODB_METADATA_TABLE'])
+
+            # Insert the item into DynamoDB
+            response = table.put_item(
+                Item={
+                    'cd2_query_job_id': nessie_job_id,
+                    'created_at': datetime.now(timezone.utc).isoformat(),
+                    'namespace': namespace,
+                    'workflow_status': 'table_query_job_triggered',
+                    'updated_at': datetime.now(timezone.utc).isoformat(),
+                    'environment': environment_name,
+                    'table_query_jobs_id': table_query_jobs,
+                    'snapshot_objects': [],
+                },
+            )
+
+            app.logger.info('CD2 metadata updated successfully in DynamoDB', response)
+            return True
+
+        except Exception as e:
+            app.logger.error(f'Error inserting CD2 metadata into DynamoDB: {str(e)}')
+            return False
+
+    def run(self, cleanup=True):
+        nessie_job_id = self.generate_job_id()
+        app.logger.info(f'Starting Query Canvas Data 2 snapshot job... (id={nessie_job_id})')
+        namespace = 'canvas'
+        cd2_tables = canvas_data_2.get_cd2_tables_list(namespace)
+
+        app.logger.info(f'{len(cd2_tables)} tables available for download from namespace {namespace}. \n{cd2_tables}')
+        app.logger.info('Begin query snapshot process for each table and retrieve job ids for tracking')
+        cd2_table_query_jobs = []
+        cd2_table_query_jobs = canvas_data_2.start_query_snapshot(cd2_tables)
+
+        failed_query_jobs = []
+        for table_job in cd2_table_query_jobs:
+            if table_job['job_status'] != 'running':
+                failed_query_jobs.append(table_job)
+
+        if failed_query_jobs:
+            app.logger.error(f'Query snapshot job trigger failed for some tables. Failed job triggers are : {failed_query_jobs}')
+        else:
+            app.logger.info(f'Started query snapshot jobs and retrived job IDs for {len(cd2_table_query_jobs)} Canvas data 2 tables')
+
+        status = self.insert_cd2_metadata(namespace, cd2_table_query_jobs, nessie_job_id)
+
+        if status is False:
+            app.logger.error('Inserting CD2 job metadata failed.')
+            return ('Inserting CD2 job metadata failed.')
+        else:
+            app.logger.info('Triggered Query snapshot Jobs on Canvas Data DAP API successfully. Inserted job metadata on DynamoDB tables')
+            return ('Triggered Query snapshot Jobs on Canvas Data DAP API successfully. Inserted job metadata on DynamoDB tables for tracking')


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1661

The Trigger Query snapshot job component does the following:

- Check for all the available tables in the CD2 Canvas namespace
- Trigger Query Job on Canvas Data Access Platform (DAP) and retrieve job IDs for each table
- Create a Dynamo DB metadata table entry of the job IDs retrieved for each table