### PR TITLE
NS-1711: remove grants on bcourses_service_reports schema

### DIFF
--- a/nessie/sql_templates/bi_grant_readonly_access.template.sql
+++ b/nessie/sql_templates/bi_grant_readonly_access.template.sql
@@ -36,8 +36,7 @@ GRANT USAGE
   ON SCHEMA 
     {redshift_schema_canvas},
     {redshift_schema_canvas_data_2},
-    {bi_redshift_schema_bcourses_service_cd2},
-    bcourses_service_reports
+    {bi_redshift_schema_bcourses_service_cd2}
   TO GROUP {bi_readonly_group};
 
 ----------------------------------------------------------------------------------------------------
@@ -48,8 +47,7 @@ GRANT SELECT ON ALL TABLES
   IN SCHEMA
     {redshift_schema_canvas},
     {redshift_schema_canvas_data_2},
-    {bi_redshift_schema_bcourses_service_cd2},
-    bcourses_service_reports
+    {bi_redshift_schema_bcourses_service_cd2}
   TO GROUP {bi_readonly_group};
 
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1711
https://jira-secure.berkeley.edu/browse/LA-1108

bcourses_service_reports does not exist in nessie_qa (redshift).