### PR TITLE
NS-1733, Calendly: fetch organziation-URI before call to events API; plus travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: required
-dist: focal
+dist: jammy
 language: python
-python: "3.8"
+python: "3.11"
+
+services:
+  - postgresql
 
 before_install:
   - cd ${TRAVIS_BUILD_DIR}
@@ -21,11 +24,7 @@ install:
   - pip install google-compute-engine # see https://github.com/tendenci/tendenci/issues/539
   - pip3 install -r requirements.txt
   - pip3 install tox
-  - echo -e '@neverendingsupport:registry=https://registry.nes.herodevs.com/npm/pkg/\n//registry.nes.herodevs.com/npm/pkg/:_authToken="'${NES_AUTH_TOKEN}'"' > .npmrc
   - npm install
 
 script:
   - tox
-
-services:
-  - postgresql

--- a/fixtures/calendly_events_list.json
+++ b/fixtures/calendly_events_list.json
@@ -1,0 +1,53 @@
+{
+  "collection": [
+    {
+      "uri": "https://api.calendly.com/scheduled_events/GBGBDCAADAEDCRZ2",
+      "name": "15 Minute Meeting",
+      "meeting_notes_plain": "Tri-weekly Sprint Planning",
+      "meeting_notes_html": "<p>We cracked jokes and not much else.</p>",
+      "status": "active",
+      "start_time": "2024-08-24T14:15:22.123456Z",
+      "end_time": "2024-08-24T14:15:22.123456Z",
+      "event_type": "https://api.calendly.com/event_types/GBGBDCAADAEDCRZ2",
+      "location": {
+        "type": "physical",
+        "location": "2850 Telegraph",
+        "additional_info": "Please check in at the main lobby."
+      },
+      "invitees_counter": {
+        "total": 0,
+        "active": 0,
+        "limit": 0
+      },
+      "created_at": "2024-01-02T03:04:05.092125Z",
+      "updated_at": "2024-01-02T03:04:05.092125Z",
+      "event_memberships": [
+        {
+          "user": "https://api.calendly.com/users/GBGBDCAADAEDCRZ2",
+          "user_email": "foo@berkeley.edu",
+          "user_name": "John Smith",
+          "buffered_end_time": "2024-08-24T14:15:22.123456Z",
+          "buffered_start_time": "2024-08-24T14:15:22.123456Z"
+        }
+      ],
+      "event_guests": [
+        {
+          "email": "baz@berkeley.edu",
+          "created_at": "2022-04-21T17:10:48.484945Z",
+          "updated_at": "2022-04-21T17:11:01.758636Z"
+        }
+      ],
+      "calendar_event": {
+        "kind": "google",
+        "external_id": "8suu9k3hj00mni03ss12ba0ce0"
+      }
+    }
+  ],
+  "pagination": {
+    "count": 20,
+    "next_page": "https://api.calendly.com/scheduled_events?count=1&page_token=sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi",
+    "previous_page": "https://api.calendly.com/scheduled_events?count=1&page_token=VJs2rfDYeY8ahZpq0QI1O114LJkNjd7H",
+    "next_page_token": "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi",
+    "previous_page_token": "VJs2rfDYeY8ahZpq0QI1O114LJkNjd7H"
+  }
+}

--- a/fixtures/calendly_organization_object.json
+++ b/fixtures/calendly_organization_object.json
@@ -1,0 +1,11 @@
+{
+  "resource": {
+    "created_at": "2024-10-04T01:15:23.586691Z",
+    "id": 1234567890,
+    "kind": "multiple",
+    "name": "UC Berkeley",
+    "plan": "enterprise",
+    "stage": "paid",
+    "updated_at": "2024-12-04T19:08:13.119740Z",
+    "uri": "https://api.calendly.com/organizations/foo-bar-baz"}
+}

--- a/nessie/externals/calendly_api.py
+++ b/nessie/externals/calendly_api.py
@@ -25,6 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from flask import current_app as app
 from nessie.lib import http
+from nessie.lib.mockingbird import fixture
 import requests
 
 
@@ -34,33 +35,58 @@ RESULT_SET_LIMIT_PER_REQUEST = 100
 
 
 def get_events(min_start_time, max_start_time):
-    def _get_events(_page_token=None):
-        # Calendly API docs: https://developer.calendly.com/api-docs/2d5ed9bbd2952-list-events
-        url = http.build_url(
-            f"{app.config['CALENDLY_BASE_URL']}/scheduled_events",
-            {
-                'count': RESULT_SET_LIMIT_PER_REQUEST,
-                'max_start_time': max_start_time,
-                'min_start_time': min_start_time,
-                'organization': app.config['CALENDLY_ORGANIZATION_UUID'],
-                'page_token': _page_token,
-                'sort': 'start_time',
-                'status': 'active',
-            },
+    def _get_events(_organization_uri, _page_token=None):
+        _feed = _get_calendly_events_list(
+            max_start_time=max_start_time,
+            min_start_time=min_start_time,
+            organization_uri=_organization_uri,
+            page_token=_page_token,
         )
-        _feed = get_authorized_response(url).json()
         _events = _feed['collection']
         _next_page_token = _feed['pagination']['next_page_token']
         return _events, _next_page_token
 
-    events, next_page_token = _get_events()
+    organization = _get_organization_object()
+    organization_uri = organization['uri']
+    events, next_page_token = _get_events(organization_uri)
     while next_page_token is not None:
-        more_events, next_page_token = _get_events(_page_token=next_page_token)
+        more_events, next_page_token = _get_events(
+            _organization_uri=organization_uri,
+            _page_token=next_page_token,
+        )
         events.extend(more_events)
     return events
 
 
-def get_authorized_response(url, mock=None):
+@fixture('calendly_events_list')
+def _get_calendly_events_list(max_start_time, min_start_time, page_token, mock=None):
+    # Calendly API docs: https://developer.calendly.com/api-docs/2d5ed9bbd2952-list-events
+    url = http.build_url(
+        f"{app.config['CALENDLY_BASE_URL']}/scheduled_events",
+        {
+            'count': RESULT_SET_LIMIT_PER_REQUEST,
+            'max_start_time': max_start_time,
+            'min_start_time': min_start_time,
+            'organization': app.config['CALENDLY_ORGANIZATION_UUID'],
+            'page_token': page_token,
+            'sort': 'start_time',
+            'status': 'active',
+        },
+    )
+    return _make_request(url, mock).json()['resource']
+
+
+@fixture('calendly_organization_object')
+def _get_organization_object(mock=None):
+    # Calendly API docs: https://developer.calendly.com/api-docs/9738aea27ba80-get-organization
+    url = http.build_url(
+        f"{app.config['CALENDLY_BASE_URL']}/scheduled_events",
+        {'uuid': app.config['CALENDLY_ORGANIZATION_UUID']},
+    )
+    return _make_request(url, mock).json()
+
+
+def _make_request(url, mock=None):
     with mock(url):
         auth_token = app.config['CALENDLY_AUTH_TOKEN']
         return requests.get(  # noqa: S113


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1733

Travis gets `dist: jammy` and python 3.11.