### PR TITLE
NS-1736, begin work on Calendly Redshift external schema

### DIFF
--- a/nessie/api/admin_controller.py
+++ b/nessie/api/admin_controller.py
@@ -95,7 +95,7 @@ def _get_user_friendly_api_name(api_path_suffix):
             result = 'BerkeleyX'
         elif w == 'urls':
             result = 'URLs'
-        elif w in ['api', 'asc', 'bi', 'boa', 'boac', 'cd2', 'coe', 'edl', 'eop', 'oua', 'rds', 's3', 'sis', 'ycbm'] or len(w) == 1:
+        elif w in ['api', 'asc', 'bi', 'boa', 'boac', 'cd2', 'coe', 'edl', 'eop', 'oua', 'rds', 's3', 'sis', 'ycbm']:
             result = w.upper()
         else:
             result = w.capitalize()
@@ -104,10 +104,11 @@ def _get_user_friendly_api_name(api_path_suffix):
     words = api_path_suffix.split('_')
     name = ' '.join([_to_proper_case(w) for w in words])
     replacements = {
+        'Bcourses': 'bCourses',
+        'C D2': 'CD2',
         'E And I': 'E&I',
         'Resync': 'Re-sync',
         'Sisedo': 'SIS EDO',
-        'Bcourses': 'bCourses',
     }
     for value, key in replacements.items():
         name = name.replace(value, key)
@@ -117,4 +118,4 @@ def _get_user_friendly_api_name(api_path_suffix):
 def _get_user_friendly_job_name(job_id):
     job_class_name = job_id.split('_')[0]
     words = split_per_camel_case(job_class_name, separator=' ').split(' ')
-    return ' '.join([_get_user_friendly_api_name(word) for word in words])
+    return _get_user_friendly_api_name('_'.join(words))

--- a/nessie/api/job_controller.py
+++ b/nessie/api/job_controller.py
@@ -40,6 +40,7 @@ from nessie.jobs.chained_import_student_population import ChainedImportStudentPo
 from nessie.jobs.create_advisor_schema import CreateAdvisorSchema
 from nessie.jobs.create_asc_advising_notes_schema import CreateAscAdvisingNotesSchema
 from nessie.jobs.create_berkeleyx_schema import CreateBerkeleyxSchema
+from nessie.jobs.create_calendly_schema import CreateCalendlySchema
 from nessie.jobs.create_canvas_schema import CreateCanvasSchema
 from nessie.jobs.create_coe_schema import CreateCoeSchema
 from nessie.jobs.create_data_science_advising_schema import CreateDataScienceAdvisingSchema
@@ -198,6 +199,13 @@ def create_sis_advising_notes_schema():
 @auth_required
 def create_student_schema():
     job_started = CreateStudentSchema().run_async()
+    return respond_with_status(job_started)
+
+
+@app.route('/api/job/create_calendly_schema', methods=['POST'])
+@auth_required
+def create_calendly_schema():
+    job_started = CreateCalendlySchema().run_async()
     return respond_with_status(job_started)
 
 

--- a/nessie/jobs/create_calendly_schema.py
+++ b/nessie/jobs/create_calendly_schema.py
@@ -1,0 +1,48 @@
+"""
+Copyright ©2025. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from flask import current_app as app
+from nessie.externals import redshift
+from nessie.jobs.background_job import BackgroundJob, BackgroundJobError, verify_external_schema
+from nessie.lib.util import resolve_sql_template
+
+"""Logic for Calendly schema creation job."""
+
+
+class CreateCalendlySchema(BackgroundJob):
+
+    def run(self):
+        app.logger.info('Starting Calendly schema creation job...')
+
+        external_schema = app.config['REDSHIFT_SCHEMA_CALENDLY']
+        redshift.drop_external_schema(external_schema)
+
+        resolved_ddl = resolve_sql_template('create_calendly_schema.template.sql')
+
+        if redshift.execute_ddl_script(resolved_ddl):
+            verify_external_schema(external_schema, resolved_ddl)
+            return 'Calendly schema creation job completed.'
+        else:
+            raise BackgroundJobError('Calendly schema creation job failed.')

--- a/nessie/jobs/import_calendly_api.py
+++ b/nessie/jobs/import_calendly_api.py
@@ -54,9 +54,7 @@ class ImportCalendlyApi(BackgroundJob):
             calendly_min_event_start = calendly_max_event_start + timedelta(days=1)
             calendly_max_event_start = calendly_min_event_start + timedelta(days=2)
         app.logger.info(f"Finished Calendly events import from {start_date.strftime('%Y-%m-%d')} to {end_date.strftime('%Y-%m-%d')}")
-        return (
-            f'Calendly API imported {total_event_count} events where start_date={start_date} and end_date={end_date}'
-        )
+        return f'Calendly API imported {total_event_count} events where start_date={start_date} and end_date={end_date}'
 
     @staticmethod
     def _put_calendly_events_to_s3(calendly_min_event_start, calendly_max_event_start):

--- a/nessie/jobs/scheduling.py
+++ b/nessie/jobs/scheduling.py
@@ -26,7 +26,8 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.background import BackgroundScheduler
 from nessie.jobs.background_job import check_for_stalled_job
-
+from nessie.jobs.create_calendly_schema import CreateCalendlySchema
+from nessie.jobs.import_calendly_api import ImportCalendlyApi
 
 """Background job scheduling."""
 
@@ -44,6 +45,7 @@ PG_ADVISORY_LOCK_IDS = {
     'JOB_REFRESH_SISEDO_INCREMENTAL': 1700,
     'JOB_IMPORT_ADVISORS': 1800,
     'JOB_IMPORT_ADMISSIONS': 1850,
+    'JOB_IMPORT_CALENDLY': 7500,
     'JOB_IMPORT_STUDENT_POPULATION': 2000,
     'JOB_IMPORT_CANVAS_ENROLLMENTS': 2900,
     'JOB_GENERATE_ALL_TABLES': 3000,
@@ -79,7 +81,7 @@ def initialize_job_schedules(_app, force=False):
         schedule_all_jobs(force)
 
 
-def schedule_all_jobs(force=False):
+def schedule_all_jobs(force=False):  # noqa: PLR0915
     from nessie.jobs.bi_grant_readonly_access import GrantBiReadonlyAccess
     from nessie.jobs.bi_refresh_boa_rds_data_schema import RefreshBiBoaRdsDataSchema
     from nessie.jobs.bi_refresh_boa_advising_schemas import RefreshBiBoaAdvisingSchemas
@@ -194,6 +196,15 @@ def schedule_all_jobs(force=False):
     schedule_job(sched, 'JOB_TRANSFORM_PIAZZA_DATA', TransformPiazzaApiData, force)
     schedule_job(sched, 'JOB_IMPORT_EDL', CreateEdlSchema, force)
     schedule_job(sched, 'JOB_UPDATE_ACADEMIC_PARTICIPATION', UpdateAcademicParticipationData, force)
+    schedule_chained_job(
+        sched,
+        'JOB_IMPORT_CALENDLY',
+        [
+            ImportCalendlyApi,
+            CreateCalendlySchema,
+        ],
+        force,
+    )
     schedule_chained_job(
         sched,
         'JOB_IMPORT_YCBM',

--- a/nessie/lib/util.py
+++ b/nessie/lib/util.py
@@ -126,6 +126,10 @@ def get_s3_boac_analytics_incremental_path(cutoff=None):
     return app.config['LOCH_S3_BOAC_ANALYTICS_DATA_PATH'] + '/incremental/' + hashed_datestamp(cutoff)
 
 
+def get_s3_calendly_daily_path(cutoff=None):
+    return app.config['LOCH_S3_CALENDLY_DATA_PATH'] + '/daily/' + hashed_datestamp(cutoff)
+
+
 def get_s3_calnet_daily_path(cutoff=None):
     return app.config['LOCH_S3_CALNET_DATA_PATH'] + '/daily/' + hashed_datestamp(cutoff)
 
@@ -211,10 +215,6 @@ def get_s3_sis_sysadm_daily_path(cutoff=None):
     return app.config['LOCH_S3_SIS_DATA_PATH'] + '/sis-sysadm/daily/' + hashed_datestamp(cutoff)
 
 
-def get_s3_calendly_daily_path(cutoff=None):
-    return app.config['LOCH_S3_CALENDLY_DATA_PATH'] + '/daily/' + hashed_datestamp(cutoff)
-
-
 def get_s3_ycbm_daily_path(cutoff=None):
     return app.config['LOCH_S3_YCBM_DATA_PATH'] + '/daily/' + hashed_datestamp(cutoff)
 
@@ -266,6 +266,8 @@ def resolve_sql_template_string(template_string, **kwargs):
         'redshift_schema_asc_advising_notes': app.config['REDSHIFT_SCHEMA_ASC_ADVISING_NOTES'],
         'redshift_schema_asc_advising_notes_internal': app.config['REDSHIFT_SCHEMA_ASC_ADVISING_NOTES_INTERNAL'],
         'redshift_schema_boac': app.config['REDSHIFT_SCHEMA_BOAC'],
+        'redshift_schema_calendly': app.config['REDSHIFT_SCHEMA_CALENDLY'],
+        'redshift_schema_calendly_internal': app.config['REDSHIFT_SCHEMA_CALENDLY_INTERNAL'],
         'redshift_schema_canvas': app.config['REDSHIFT_SCHEMA_CANVAS'],
         'redshift_schema_canvas_data_2': app.config['REDSHIFT_SCHEMA_CANVAS_DATA_2'],
         'redshift_schema_coe': app.config['REDSHIFT_SCHEMA_COE'],
@@ -294,6 +296,7 @@ def resolve_sql_template_string(template_string, **kwargs):
         'redshift_iam_role': app.config['REDSHIFT_IAM_ROLE'],
         'loch_s3_asc_data_path': s3_prefix + get_s3_asc_daily_path(),
         'loch_s3_boac_analytics_incremental_path': s3_prefix + get_s3_boac_analytics_incremental_path(),
+        'loch_s3_calendly_data_path': s3_prefix + app.config['LOCH_S3_CALENDLY_DATA_PATH'],
         'loch_s3_calnet_data_path': s3_prefix + get_s3_calnet_daily_path(),
         'loch_s3_canvas_data_path_today': s3_prefix + get_s3_canvas_daily_path(),
         'loch_s3_canvas_data_2_path_today': s3_prefix + get_s3_canvas_data_2_daily_path(),

--- a/nessie/sql_templates/create_calendly_schema.template.sql
+++ b/nessie/sql_templates/create_calendly_schema.template.sql
@@ -1,0 +1,128 @@
+/**
+ * Copyright ©2025. The Regents of the University of California (Regents). All Rights Reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation
+ * for educational, research, and not-for-profit purposes, without fee and without a
+ * signed licensing agreement, is hereby granted, provided that the above copyright
+ * notice, this paragraph and the following two paragraphs appear in all copies,
+ * modifications, and distributions.
+ *
+ * Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+ * Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+ * http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+ *
+ * IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+ * INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+ * THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ * SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+ * "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ * ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+--------------------------------------------------------------------
+-- CREATE EXTERNAL SCHEMA
+--------------------------------------------------------------------
+
+CREATE EXTERNAL SCHEMA {redshift_schema_calendly}
+FROM data catalog
+DATABASE '{redshift_schema_calendly}'
+IAM_ROLE '{redshift_iam_role}'
+CREATE EXTERNAL DATABASE IF NOT EXISTS;
+
+--------------------------------------------------------------------
+-- External Tables
+--------------------------------------------------------------------
+
+-- events
+CREATE EXTERNAL TABLE {redshift_schema_calendly}.events(
+      id VARCHAR,
+      title VARCHAR,
+      startsAt VARCHAR,
+      endsAt VARCHAR,
+      cancelled BOOLEAN,
+      cancellationReason CHAR(max),
+      teamMember STRUCT<id: VARCHAR, name: VARCHAR, email: VARCHAR>,
+      answers STRUCT<sid: VARCHAR, email: VARCHAR, fname: VARCHAR, q5: CHAR(max), q6: CHAR(max)>,
+      importedAt VARCHAR
+)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES ('ignore.malformed.json' = 'true')
+LOCATION '{loch_s3_calendly_data_path}/archive';
+
+--------------------------------------------------------------------
+-- Internal schema
+--------------------------------------------------------------------
+
+DROP SCHEMA IF EXISTS {redshift_schema_calendly_internal} CASCADE;
+CREATE SCHEMA {redshift_schema_calendly_internal};
+GRANT USAGE ON SCHEMA {redshift_schema_calendly_internal} TO GROUP {redshift_app_boa_user}_group;
+ALTER default PRIVILEGES IN SCHEMA {redshift_schema_calendly_internal} GRANT SELECT ON TABLES TO GROUP {redshift_app_boa_user}_group;
+GRANT USAGE ON SCHEMA {redshift_schema_calendly_internal} TO GROUP {redshift_dblink_group};
+ALTER DEFAULT PRIVILEGES IN SCHEMA {redshift_schema_calendly_internal} GRANT SELECT ON TABLES TO GROUP {redshift_dblink_group};
+
+--------------------------------------------------------------------
+-- Internal tables
+--------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION {redshift_schema_calendly_internal}.to_utc_iso_string(date_string VARCHAR)
+RETURNS VARCHAR
+STABLE
+AS $$
+  from datetime import datetime
+  import pytz
+
+  d = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S')
+  d = pytz.timezone('America/Los_Angeles').localize(d)
+  return d.astimezone(pytz.utc).isoformat()
+$$ language plpythonu;
+
+GRANT EXECUTE
+ON function {redshift_schema_calendly_internal}.to_utc_iso_string(VARCHAR)
+TO GROUP {redshift_app_boa_user}_group;
+
+CREATE TABLE {redshift_schema_calendly_internal}.events
+SORTKEY (id)
+AS (
+  SELECT
+    t.id,
+    NULL::VARCHAR(10) AS ldap_uid,
+    t.answers.sid AS calendly_sid,
+    t.answers.email AS calendly_student_email,
+    t.answers.fname AS calendly_student_name,
+    t.title,
+    TO_TIMESTAMP({redshift_schema_calendly_internal}.to_utc_iso_string(t.startsat), 'YYYY-MM-DD"T"HH.MI.SS%z') AS starts_at,
+    TO_TIMESTAMP({redshift_schema_calendly_internal}.to_utc_iso_string(t.endsat), 'YYYY-MM-DD"T"HH.MI.SS%z') AS ends_at,
+    t.cancelled,
+    t.cancellationreason AS cancellation_reason,
+    t.teammember.id AS advisor_id,
+    t.teammember.name AS advisor_name,
+    t.teammember.email AS advisor_email,
+    t.answers.q5 AS q5,
+    t.answers.q6 AS q6,
+    MAX(t.importedat) AS imported_at
+  FROM {redshift_schema_calendly}.events t
+  GROUP BY
+    t.id, t.title, t.startsat, t.endsat, t.cancelled, t.cancellationreason,
+    t.teammember.id, t.teammember.name, t.teammember.email,
+    t.answers.sid, t.answers.email, t.answers.fname, t.answers.q5, t.answers.q6
+);
+
+DROP FUNCTION {redshift_schema_calendly_internal}.to_utc_iso_string(VARCHAR);
+
+UPDATE {redshift_schema_calendly_internal}.events
+SET ldap_uid = ba.ldap_uid
+FROM {redshift_schema_edl}.basic_attributes ba
+  JOIN {redshift_schema_calendly_internal}.events b
+  ON ba.sid = b.calendly_sid;
+
+-- Second pass: try to fill in remaining UIDs from CalNet matches on email address.
+UPDATE {redshift_schema_calendly_internal}.events
+SET ldap_uid = ba.ldap_uid
+FROM {redshift_schema_edl}.basic_attributes ba
+  JOIN {redshift_schema_calendly_internal}.events b
+  ON ba.email_address = b.calendly_student_email
+  AND b.ldap_uid IS NULL;

--- a/src/assets/scss/global.scss
+++ b/src/assets/scss/global.scss
@@ -72,3 +72,6 @@ a {
 .striped-table .v-data-table__td-title {
   font-weight: bold !important;
 }
+.vertical-top {
+  vertical-align: top !important;
+}

--- a/src/views/JobTable.vue
+++ b/src/views/JobTable.vue
@@ -86,25 +86,31 @@
             </v-alert>
             <v-data-table
               :headers="[
-                {key: 'id', title: 'Job', sortable: jobs.all.length > 1},
+                {
+                  key: 'id',
+                  cellProps: {class: 'vertical-top'},
+                  sortable: jobs.all.length > 1,
+                  title: 'Job',
+                  width: 360
+                },
                 {
                   key: 'status',
                   cellProps: item => {
                     if (item.value === 'failed') {
-                      return {class: 'bg-red-lighten-4 text-center'}
+                      return {class: 'bg-red-lighten-4 vertical-top'}
                     } else if (item.value === 'started') {
-                      return {class: 'bg-blue-lighten-4'}
+                      return {class: 'bg-blue-lighten-4 vertical-top'}
                     } else {
-                      return {class: 'bg-green-lighten-4'}
+                      return {class: 'bg-green-lighten-4 vertical-top'}
                     }
                   },
                   sortable: jobs.all.length > 1,
                   title: 'Status'
                 },
-                {key: 'details', title: 'Summary', sortable: false},
-                {key: 'started', title: 'Start (UTC)', sortable: jobs.all.length > 1},
-                {key: 'finished', title: 'End (UTC)', sortable: jobs.all.length > 1},
-                {key: 'duration', title: 'Duration (hh:mm:ss)', sortable: jobs.all.length > 1}
+                {key: 'details', cellProps: {class: 'vertical-top'}, sortable: false, title: 'Summary'},
+                {key: 'started', cellProps: {class: 'vertical-top'}, sortable: jobs.all.length > 1, title: 'Start (UTC)'},
+                {key: 'finished', cellProps: {class: 'vertical-top'}, sortable: jobs.all.length > 1, title: 'End (UTC)'},
+                {key: 'duration', cellProps: {class: 'vertical-top'}, sortable: jobs.all.length > 1, title: 'Duration (hh:mm:ss)'}
               ]"
               :items="jobs.all"
               items-per-page="-1"
@@ -112,12 +118,15 @@
               :mobile="xs"
             >
               <template #item.id="{ item }">
-                {{ item.name }}
+                <span class="text-subtitle-2 font-weight-bold text-medium-emphasis">{{ item.name }}</span>
               </template>
               <template #item.status="{ item }">
-                <div class="d-flex justify-center">
-                  <div>
-                    {{ item.status }}
+                <div class="align-center d-flex">
+                  <div v-if="item.status.includes('fail')" class="font-weight-bold text-medium-emphasis">
+                    {{ toUpper(item.status) }}
+                  </div>
+                  <div v-if="!item.status.includes('fail')">
+                    {{ capitalize(item.status) }}
                   </div>
                   <v-tooltip
                     v-if="(item.status === 'started') && !item.finished && getAgeInHours(item) > 5"
@@ -130,7 +139,7 @@
                 </div>
               </template>
               <template #item.details="{ item }">
-                <div v-html="item.details"></div>
+                <div v-html="item.details" />
               </template>
               <template #item.started="{ item }">
                 {{ toFormatFromISO(item.started, "HH:mm:ss") }}
@@ -186,7 +195,7 @@
 </template>
 
 <script setup>
-import {capitalize, each, find, get, map, replace, split} from 'lodash'
+import {capitalize, each, find, get, map, replace, split, toUpper} from 'lodash'
 import {DateTime} from 'luxon'
 import {mdiCheck, mdiHelpBox} from '@mdi/js'
 import {computed, onMounted, onUnmounted, ref} from 'vue'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1736

The `create_calendly_schema.template.sql` is using YCBM template as reference impl and contains column references that need to be migrated to match Calendly feed.