### PR TITLE
NO-JIRA, you can now have a personalized .gitignore.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Register a personalized '.gitignore.local' file with the command:
+#   git config --local core.excludesFile .gitignore.local
+.gitignore.local
+
 # IDE-related
 .idea
 .vscode


### PR DESCRIPTION
@pauline2k @lyttam @mohamalnadi - If you want files ignored and yet registering them in standard `.gitignore` seems like too much, then:
1. create `.gitignore.local`
2. run command: `git config --local core.excludesFile .gitignore.local`

Or, do none of that and carry on.