### PR TITLE
NS-1749, only Calendly events with SID are imported

### DIFF
--- a/nessie/externals/calendly_api.py
+++ b/nessie/externals/calendly_api.py
@@ -34,6 +34,7 @@ import requests
 
 """Calendly API."""
 
+CALENDLY_API_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 RESULT_SET_LIMIT_PER_REQUEST = 100
 
 
@@ -130,4 +131,4 @@ def _get_authorized_response(url, mock=None):
 
 
 def _to_calendly_date_format(value):
-    return value.astimezone(pytz.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    return value.astimezone(pytz.utc).strftime(CALENDLY_API_DATE_FORMAT)

--- a/nessie/jobs/import_calendly_api.py
+++ b/nessie/jobs/import_calendly_api.py
@@ -29,6 +29,7 @@ import json
 from flask import current_app as app
 from nessie.externals import s3
 from nessie.externals import calendly_api
+from nessie.externals.calendly_api import CALENDLY_API_DATE_FORMAT
 from nessie.jobs.background_job import BackgroundJob
 from nessie.lib.util import get_s3_calendly_daily_path, hashed_datestamp, localize_datetime, utc_now
 
@@ -65,13 +66,25 @@ class ImportCalendlyApi(BackgroundJob):
             max_start_time=max_event_start,
         )
         if len(events):
-            imported_at = utc_now().strftime('%Y-%m-%dT%H:%M:%SZ')
+            serialized_data = ''
+            imported_at = utc_now().strftime(CALENDLY_API_DATE_FORMAT)
 
             def _extract_event_uuid(event_uri):
                 return event_uri.split('/')[-1]
             events_by_uuid = {_extract_event_uuid(event['uri']): event for event in events}
             for uuid, event in events_by_uuid.items():
+                event['uuid'] = uuid
                 event['invitees'] = []
+                # Extract host info
+                event['hosts'] = []
+                for event_membership in event.get('event_memberships', []):
+                    event['hosts'].append({
+                        'email': event_membership['user_email'],
+                        'name': event_membership['user_name'],
+                        'uri': event_membership['user'],
+                    })
+                # Extract student info
+                includes_invitee_with_sid = False
                 for event_invitee in calendly_api.get_event_invitees(uuid):
                     invitee = {
                         **{k: event_invitee[k] for k in ['email', 'name'] if k in event_invitee},
@@ -84,16 +97,19 @@ class ImportCalendlyApi(BackgroundJob):
                         if question and answer:
                             if 'Student Identification Number (SID)' in question:
                                 invitee['sid'] = answer
+                                includes_invitee_with_sid = True
                             else:
                                 invitee['questions_and_answers'].append({'question': question, 'answer': answer})
                     event['invitees'].append(invitee)
-            serialized_data = ''
-            for e in events:
-                # Remove noisy Zoom info.
-                if e.get('location', {}).get('type', None) == 'zoom':
-                    del e['location']
-                # JsonSerDe schema creation in Redshift via JSON records in S3.
-                serialized_data += json.dumps({'imported_at': imported_at, **e}) + '\n'
+                if len(event['hosts']) and includes_invitee_with_sid:
+                    # Remove noisy Zoom info.
+                    if event.get('location', {}).get('type', None) == 'zoom':
+                        del event['location']
+                    # Remove other extraneous elements
+                    for key in ('calendar_event', 'event_type', 'invitees_counter', 'event_guests', 'event_memberships'):
+                        del event[key]
+                    # JsonSerDe schema creation in Redshift via JSON records in S3.
+                    serialized_data += json.dumps({'imported_at': imported_at, **event}) + '\n'
             s3_directory = f"{min_event_start.strftime('%Y-%m-%d')}_to_{max_event_start.strftime('%Y-%m-%d')}"
             s3.upload_data(
                 data=serialized_data,

--- a/nessie/sql_templates/create_calendly_schema.template.sql
+++ b/nessie/sql_templates/create_calendly_schema.template.sql
@@ -39,16 +39,19 @@ CREATE EXTERNAL DATABASE IF NOT EXISTS;
 
 -- events
 CREATE EXTERNAL TABLE {redshift_schema_calendly}.events(
-    calendar_event STRUCT<id: VARCHAR, kind: VARCHAR>,
-    start_time VARCHAR,
     end_time VARCHAR,
+    hosts ARRAY<VARCHAR>,
+    invitees ARRAY<VARCHAR>,
     meeting_notes_html VARCHAR,
     meeting_notes_plain VARCHAR,
     name VARCHAR,
+    start_time VARCHAR,
     status VARCHAR,
-    updated_at VARCHAR,
     uri VARCHAR,
-    imported_at VARCHAR
+    uuid VARCHAR,
+    created_at VARCHAR,
+    imported_at VARCHAR,
+    updated_at VARCHAR
 )
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
 WITH SERDEPROPERTIES ('ignore.malformed.json' = 'true')
@@ -101,7 +104,7 @@ AS (
     MAX(e.imported_at) AS imported_at
   FROM {redshift_schema_calendly}.events e
   GROUP BY
-    e.calendar_event.id, e.name, e.start_time, e.end_time, e.meeting_notes_html, e.meeting_notes_plain, e.status, e.uri
+    e.uuid, e.name, e.start_time, e.end_time, e.meeting_notes_html, e.meeting_notes_plain, e.status, e.uri
 );
 
 DROP FUNCTION {redshift_schema_calendly_internal}.to_utc_iso_string(VARCHAR);


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1749

And the JSON put to S3 is more compact. We capture only what we want.