### PR TITLE
NS-1777, Calendly: Use student email_address to deduce SID

### DIFF
--- a/nessie/jobs/import_calendly_api.py
+++ b/nessie/jobs/import_calendly_api.py
@@ -101,12 +101,13 @@ def _serialize_calendly_events(events):
             event['host_name'] = event_membership['user_name']
             event['host_uri'] = event_membership['user']
         # Extract student info
-        includes_invitee_with_sid = False
+        has_student_email_addresses = False
         for event_invitee in calendly_api.get_event_invitees(uuid):
             student = {
-                **{k: event_invitee[k] for k in ['email', 'name', 'rescheduled', 'status'] if k in event_invitee},
+                **{k: event_invitee[k] for k in ['email', 'name', 'status'] if k in event_invitee},
                 'questions_and_answers': None,
                 'no_show': bool(event_invitee['no_show']),
+                'rescheduled': bool(event_invitee['rescheduled']),
                 'sid': None,
             }
             questions_and_answers = []
@@ -114,16 +115,12 @@ def _serialize_calendly_events(events):
                 question = question_and_answer.get("question")
                 answer = question_and_answer.get("answer")
                 if question and answer:
-                    if 'Student Identification Number (SID)' in question:
-                        student['sid'] = answer
-                        includes_invitee_with_sid = True
-                    else:
-                        questions_and_answers.append({'question': question, 'answer': answer})
+                    questions_and_answers.append({'question': question, 'answer': answer})
             student['questions_and_answers'] = json.dumps(questions_and_answers)
-            if includes_invitee_with_sid:
-                event['student'] = student
-                break
-        if event['host_email'] and includes_invitee_with_sid:
+            has_student_email_addresses = bool(has_student_email_addresses or student.get('email'))
+
+        # Events must have student email; we will use email address to look up student SID.
+        if event['host_email'] and has_student_email_addresses:
             # Remove noisy Zoom info.
             if event.get('location', {}).get('type', None) == 'zoom':
                 del event['location']

--- a/nessie/sql_templates/create_calendly_schema.template.sql
+++ b/nessie/sql_templates/create_calendly_schema.template.sql
@@ -107,8 +107,6 @@ AS (
     e.student.name AS student_name,
     e.student.no_show AS is_student_no_show,
     e.student.rescheduled AS is_rescheduled,
-    e.student.sid AS student_sid,
-    NULL::VARCHAR(10) AS student_uid,
     e.student.questions_and_answers AS questions_and_answers,
     e.uri,
     TO_TIMESTAMP(e.created_at, 'YYYY-MM-DD"T"HH.MI.SS.MSZ') AS created_at,
@@ -118,7 +116,7 @@ AS (
   GROUP BY
     e.uuid, e.canceled_at, e.canceled_by, e.cancellation_reason, e.end_time, e.host_email, e.host_name, e.host_uri,
     e.meeting_notes_html, e.meeting_notes_plain, e.name, e.start_time, e.status, e.student.email, e.student.name,
-    e.student.no_show, e.student.rescheduled, e.student.sid, e.student.questions_and_answers, e.uri, e.created_at,
+    e.student.no_show, e.student.rescheduled, e.student.questions_and_answers, e.uri, e.created_at,
     e.updated_at
 );
 
@@ -133,15 +131,3 @@ UPDATE {redshift_schema_calendly_internal}.events
 SET host_sid = b.sid
 FROM {redshift_schema_edl}.basic_attributes b
   JOIN {redshift_schema_calendly_internal}.events e ON e.host_uid = b.ldap_uid;
-
--- Student UID
-UPDATE {redshift_schema_calendly_internal}.events
-SET student_uid = b.ldap_uid
-FROM {redshift_schema_edl}.basic_attributes b
-  JOIN {redshift_schema_calendly_internal}.events e ON e.student_sid = b.sid;
-
--- Student UID fallback
-UPDATE {redshift_schema_calendly_internal}.events
-SET student_uid = b.ldap_uid
-FROM {redshift_schema_edl}.basic_attributes b
-  JOIN {redshift_schema_calendly_internal}.events e ON UPPER(b.email_address) = UPPER(e.student_email) AND e.student_uid IS NULL;

--- a/nessie/sql_templates/index_advising_notes.template.sql
+++ b/nessie/sql_templates/index_advising_notes.template.sql
@@ -194,6 +194,7 @@ CREATE TABLE {rds_schema_advising_appointments}.calendly_advising_appointments (
   meeting_notes_plain TEXT,
   questions_and_answers TEXT,
   start_time TIMESTAMP WITH TIME ZONE,
+  student_email VARCHAR,
   student_sid VARCHAR,
   student_uid VARCHAR,
   title VARCHAR,
@@ -220,12 +221,14 @@ INSERT INTO {rds_schema_advising_appointments}.calendly_advising_appointments (
       e.meeting_notes_plain,
       e.questions_and_answers,
       e.start_time,
-      e.student_sid,
-      e.student_uid,
+      e.student_email,
+      s.sid AS student_sid,
+      s.ldap_uid AS student_uid,
       e.title,
       e.created_at,
       e.updated_at
     FROM {redshift_schema_calendly_internal}.events e
+    JOIN {redshift_schema_edl}.basic_attributes s ON s.email_address ILIKE e.student_email
     JOIN (SELECT e2.id, MAX(e2.imported_at) AS imported_at FROM {redshift_schema_calendly_internal}.events e2 GROUP BY e2.id) latest
       ON e.id = latest.id and e.imported_at = latest.imported_at
     ORDER BY start_time DESC
@@ -245,6 +248,7 @@ INSERT INTO {rds_schema_advising_appointments}.calendly_advising_appointments (
       meeting_notes_plain TEXT,
       questions_and_answers TEXT,
       start_time TIMESTAMP WITH TIME ZONE,
+      student_email VARCHAR,
       student_sid VARCHAR,
       student_uid VARCHAR,
       title VARCHAR,


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1777

No longer do we rely on students to know (and properly enter) their own SIDs.