### PR TITLE
NS-1779, index_advising_notes.sql: I no like ILIKE when comparing email addresses

### DIFF
--- a/nessie/sql_templates/index_advising_notes.template.sql
+++ b/nessie/sql_templates/index_advising_notes.template.sql
@@ -228,7 +228,7 @@ INSERT INTO {rds_schema_advising_appointments}.calendly_advising_appointments (
       e.created_at,
       e.updated_at
     FROM {redshift_schema_calendly_internal}.events e
-    JOIN {redshift_schema_edl}.basic_attributes s ON s.email_address ILIKE e.student_email
+    JOIN {redshift_schema_edl}.basic_attributes s ON LOWER(s.email_address) = LOWER(e.student_email)
     JOIN (SELECT e2.id, MAX(e2.imported_at) AS imported_at FROM {redshift_schema_calendly_internal}.events e2 GROUP BY e2.id) latest
       ON e.id = latest.id and e.imported_at = latest.imported_at
     ORDER BY start_time DESC


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1779

SQL `ILIKE` treats underscores as wildcards and that's a problem when comparing email addresses.