### PR TITLE
NS-1786, redshift db migrate script to add acad_standing_description to student.academic_standing

### DIFF
--- a/scripts/migrate/20250815-NS-1786/redshift_pre_deploy_add_column_acad_standing_description.sql
+++ b/scripts/migrate/20250815-NS-1786/redshift_pre_deploy_add_column_acad_standing_description.sql
@@ -1,0 +1,38 @@
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS student.academic_standing_new
+(
+    sid VARCHAR NOT NULL,
+    term_id VARCHAR NOT NULL,
+    acad_standing_action VARCHAR,
+    acad_standing_description VARCHAR,
+    acad_standing_status VARCHAR,
+    action_date VARCHAR
+)
+DISTKEY (sid)
+SORTKEY (sid);
+
+INSERT INTO student.academic_standing_new (
+    SELECT sid, term_id, acad_standing_action, NULL AS acad_standing_description, acad_standing_status, action_date
+    FROM student.academic_standing
+);
+
+DROP TABLE student.academic_standing;
+ALTER TABLE student.academic_standing_new RENAME TO academic_standing;
+
+-- Drop and (re)create the staging table.
+DROP TABLE student_staging.academic_standing;
+
+CREATE TABLE student_staging.academic_standing
+(
+    sid VARCHAR NOT NULL,
+    term_id VARCHAR NOT NULL,
+    acad_standing_action VARCHAR,
+    acad_standing_description VARCHAR,
+    acad_standing_status VARCHAR,
+    action_date VARCHAR
+)
+DISTKEY (sid)
+SORTKEY (sid);
+
+COMMIT;


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1786

I'll need @pauline2k to review this one. Afaik, the 'student' schema in Redshift is never dropped and recreated; therefore, my previous schema changes in `create_student_schema.template.sql` (see PR #1581) are never applied because `CREATE TABLE IF NOT EXISTS` does nothing to an existing table.

Is this the proper migrate script given my dilemma? Thanks @pauline2k  :)