### PR TITLE
NS-1787, more sensible retry logic for Calendly API

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -109,10 +109,7 @@ CALENDLY_BASE_API_URL = 'https://api.calendly.com'
 CALENDLY_FETCH_DAYS_AHEAD = 30
 CALENDLY_FETCH_DAYS_BEHIND = 3
 CALENDLY_ORGANIZATION_UUID = 'some organization UUID'
-CALENDLY_RETRY_SETTINGS = {
-    'retry_count': 2,
-    'sleep_seconds_between_retries': 2,
-}
+CALENDLY_RETRY_IF_API_ERROR = False
 
 CANVAS_DATA_API_KEY = 'some key'
 CANVAS_DATA_API_SECRET = 'some secret'  # noqa: S105

--- a/nessie/externals/calendly_api.py
+++ b/nessie/externals/calendly_api.py
@@ -116,13 +116,12 @@ def _make_calendly_api_request(path, query=None):
 
 @fixture('calendly_scheduled_events')
 def _get_authorized_response(url, mock=None):
-    response_status_code = None
-    api_attempts = 0
     with mock(url):
-        calendly_retry_settings = app.config['CALENDLY_RETRY_SETTINGS']
-        retry_count = calendly_retry_settings['retry_count']
-        while api_attempts < retry_count:
-            api_attempts += 1
+        # If 'RETRY' is enabled then we pause and retry one time.
+        retry_if_api_error = app.config['CALENDLY_RETRY_IF_API_ERROR']
+        api_attempts = 2 if retry_if_api_error else 1
+        response_status_code = None
+        for attempt in range(api_attempts):
             response = requests.get(  # noqa: S113
                 headers={
                     'Authorization': f"Bearer {app.config['CALENDLY_AUTH_TOKEN']}",
@@ -131,13 +130,19 @@ def _get_authorized_response(url, mock=None):
                 url=url,
             )
             response_status_code = response.status_code
-            if response_status_code != 200:
-                time.sleep(calendly_retry_settings['sleep_seconds_between_retries'])
+            retry_the_api_call = response_status_code != 200 and retry_if_api_error and attempt < api_attempts - 1
+            if retry_the_api_call:
+                time.sleep(2)
                 app.logger.warning(f'Retrying Calendly API request: {url}')
 
         if response_status_code != 200:
-            app.logger.warning(f'Calendly API call failed: {url} (retries = {retry_count})')
-            raise BackgroundJobError(f'Failed GET {url} (status_code: {response_status_code}) due to {response.text}')
+            app.logger.warning(f'Calendly API call failed: {url}')
+            raise BackgroundJobError(f"""
+                Calendly API call failed {'(twice with retry)' if retry_if_api_error else ''}
+                URL: {url}
+                HTTP status code: {response_status_code}
+                {response.text}
+            """)
         return response
 
 

--- a/tests/test_externals/test_calendly_api.py
+++ b/tests/test_externals/test_calendly_api.py
@@ -30,19 +30,48 @@ import pytz
 from nessie.externals import calendly_api
 from nessie.jobs.background_job import BackgroundJobError
 from nessie.lib.mockingbird import MockResponse, register_mock
+from tests.util import override_config
 
 
 class TestCalendlyApi:
     """Calendly API client."""
 
-    def test_calendly_server_error(self, app):
-        """Logs unexpected Calendly server errors."""
+    def test_calendly_server_error_with_retry(self, app):
+        """Retry Calendly API if error."""
         with app.app_context():
             calendly_error = MockResponse(500, {}, '{"message": "Internal server error."}')
-            with register_mock(calendly_api._get_authorized_response, calendly_error):
+            with (
+                register_mock(calendly_api._get_authorized_response, calendly_error),
+                override_config(app, 'CALENDLY_RETRY_IF_API_ERROR', True),
+            ):
                 with pytest.raises(BackgroundJobError) as error:
                     calendly_api.get_scheduled_events(
                         min_start_time=datetime.now(pytz.utc),
                         max_start_time=datetime.now(pytz.utc) + timedelta(days=1),
                     )
-                assert 'Failed GET https://api.calendly.com/organizations' in str(error.value)
+                # Verify that retry DID happen.
+                for snippet in (
+                    'Calendly API call failed (twice with retry)',
+                    'URL: https://api.calendly.com/organizations',
+                ):
+                    assert snippet in str(error.value)
+
+    def test_calendly_server_error_without_retry(self, app):
+        """Do NOT retry Calendly API if error."""
+        with app.app_context():
+            calendly_error = MockResponse(500, {}, '{"message": "Internal server error."}')
+            with (
+                register_mock(calendly_api._get_authorized_response, calendly_error),
+                override_config(app, 'CALENDLY_RETRY_IF_API_ERROR', False),
+            ):
+                with pytest.raises(BackgroundJobError) as error:
+                    calendly_api.get_scheduled_events(
+                        min_start_time=datetime.now(pytz.utc),
+                        max_start_time=datetime.now(pytz.utc) + timedelta(days=1),
+                    )
+                # Verify that retry DID NOT happen.
+                for snippet in (
+                    'Calendly API call failed',
+                    'URL: https://api.calendly.com/organizations',
+                ):
+                    assert snippet in str(error.value)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/NS-1787

A simple config. (Release instructions updated.)