### PR TITLE
NS-1826: Modify .ebextensions to address log streaming and retention

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -1,3 +1,21 @@
+# AWS configuration for Nessie
+#
+packages:
+  yum:
+    gcc-c++: []
+    git: []
+    postgresql15: []
+
+option_settings:
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    DeleteOnTerminate: false
+  aws:elasticbeanstalk:environment:proxy:
+    ProxyServer: apache
+  aws:elasticbeanstalk:environment:proxy:staticfiles:
+    /assets: dist/static/assets
+    /favicon.ico: dist/static/favicon.ico
+
 files:
   "/tmp/amazon-cloudwatch-agent.json":
     mode: "000644"
@@ -81,18 +99,18 @@ files:
               "collect_list": [
                 {
                   "file_path": "/var/app/current/nessie.log*",
-                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/app/current/nessie.log\"]]}`",
+                  "log_group_name": "`{"Fn::Sub":"/aws/elasticbeanstalk/${AWSEBEnvironmentName}/var/app/current/nessie.log"}`",
                   "log_stream_name": "{instance_id}"
                 },
                 {
                   "file_path": "/var/log/messages",
-                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/log/messages\"]]}`",
+                  "log_group_name": "`{"Fn::Sub":"/aws/elasticbeanstalk/${AWSEBEnvironmentName}/var/log/messages"}`",
                   "log_stream_name": "{instance_id}-messages",
                   "timestamp_format": "%b %d %H:%M:%S"
                 },
                 {
                   "file_path": "/var/log/secure",
-                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/log/secure\"]]}`",
+                  "log_group_name": "`{"Fn::Sub":"/aws/elasticbeanstalk/${AWSEBEnvironmentName}/var/log/secure"}`",
                   "log_stream_name": "{instance_id}-secure",
                   "timestamp_format": "%b %d %H:%M:%S"
                 }
@@ -101,20 +119,3 @@ files:
           }
         }
       }
-
-packages:
-  yum:
-    gcc-c++: []
-    git: []
-    postgresql15: []
-
-option_settings:
-  aws:elasticbeanstalk:cloudwatch:logs:
-    StreamLogs: true
-    DeleteOnTerminate: false
-    RetentionInDays: 180
-  aws:elasticbeanstalk:environment:proxy:
-    ProxyServer: apache
-  aws:elasticbeanstalk:environment:proxy:staticfiles:
-    /assets: dist/static/assets
-    /favicon.ico: dist/static/favicon.ico


### PR DESCRIPTION
As the title states, this will resolve log streaming issues to cloudwatch, and address the log retention setting being overwritten which each deployment.